### PR TITLE
ci: fix commitlint workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Setup node
         uses: actions/setup-node@v2
@@ -33,7 +35,7 @@ jobs:
 
       - name: Check commit message
         if: ${{ github.event_name == 'pull_request' }}
-        run: yarn commitlint ${{ github.context.payload.before }}
+        run: yarn commitlint ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
 
       - name: Linting & Unit testing
         run: |

--- a/sbin/commitlint.sh
+++ b/sbin/commitlint.sh
@@ -1,31 +1,29 @@
 #!/usr/bin/env bash
 
-CONVENTIONAL_COMMIT_REGEX='^(fix|feat|chore|docs|refactor)(\([[:alnum:]_]+\))?!?:[[:space:]][^[:space:]](.*)[^.]$'
+CONVENTIONAL_COMMIT_REGEX='^(fix|feat|chore|docs|refactor|ci)(\([[:alnum:]_]+\))?!?:[[:space:]][^[:space:]](.*)[^.]$'
 
 function usage {
   cat <<EOF
-  Usage: $(basename $0) [commitish]
+  Usage: $(basename $0) [range]
   
-  The optional argument indicates the commit to start the check from,
-  and the range that is checked will be <commitish>..HEAD.
-  Note that the commitish itself is not included (to start from
-  e.g. fa56eb, you would write fa56eb~ to use the parent as starting
-  point).
-
-  If no commitish is given, HEAD~ is used (so only the current commit
+  If no range is given, HEAD~..HEAD is used (so only the latest commit
   will be checked).
+
+  Note that the a range fa56eb..HEAD does not include the fa56eb commit
+  (to start from e.g. fa56eb, you would write fa56eb~..HEAD to use the parent
+  as starting point).
 
   Check if message conforms to a conventional commit message, see
   https://www.conventionalcommits.org/en/v1.0.0/#specification
 EOF
 }
 
-start="HEAD~"
+range="HEAD~..HEAD"
 if [[ ! -z "$1" ]]; then
-  start="$1"
+  range="$1"
 fi
 
-for sha in $(git rev-list "$start..HEAD"); do
+for sha in $(git rev-list "$range" || exit 1); do
   msg=$(git log -1 --format="%s" $sha)
   if [[ ! "$msg" =~ $CONVENTIONAL_COMMIT_REGEX ]]; then
     echo "bad commit message:"


### PR DESCRIPTION
Change commitlint to work on ranges, and update the Github workflow to
send in the merge requests `<base>..<head>` as the range.