### PR TITLE
ci: newer ubuntu, run default headed

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: ['14', '15']
@@ -53,7 +53,7 @@ jobs:
 
   ui-tests:
     needs: unit-tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -77,7 +77,6 @@ jobs:
           install-command: yarn install --immutable --immutable-cache
           start: yarn cypress:ui-tests
           browser: ${{ matrix.browser }}
-          headless: true
           working-directory: packages/ui-tests
           wait-on: 'http://localhost:9009'
           command-prefix: yarn workspace practical-react-components-ui-tests
@@ -91,7 +90,7 @@ jobs:
 
   docs:
     needs: unit-tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
We had some issues with Chrome on the older Ubuntu (at least when
running in headless mode). This steps up the Ubuntu version to 20.04 and
runs the browsers in the default headed mode.