### PR TITLE
refactor: split out selector from base select

### DIFF
--- a/.yarn/versions/97a94915.yml
+++ b/.yarn/versions/97a94915.yml
@@ -1,0 +1,5 @@
+releases:
+  practical-react-components: minor
+
+undecided:
+  - practical-react-components-core

--- a/packages/core/src/Input/__snapshots__/index.test.tsx.snap
+++ b/packages/core/src/Input/__snapshots__/index.test.tsx.snap
@@ -4217,6 +4217,42 @@ exports[`TextInput TimeInput 1`] = `
   white-space: nowrap;
 }
 
+.c24 {
+  height: 40px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: rgb(82,82,82);
+  cursor: default;
+}
+
+.c26 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c27 {
+  color: rgb(82,82,82);
+  margin-left: 8px;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
 .c29 {
   position: fixed;
   top: 0;
@@ -4257,10 +4293,6 @@ exports[`TextInput TimeInput 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   height: 100%;
-  width: 100%;
-}
-
-.c9 {
   width: 100%;
 }
 
@@ -4315,40 +4347,8 @@ exports[`TextInput TimeInput 1`] = `
   padding: 2px;
 }
 
-.c24 {
-  height: 40px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: rgb(82,82,82);
-  cursor: default;
-}
-
-.c26 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c27 {
-  color: rgb(82,82,82);
-  margin-left: 8px;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
+.c9 {
+  width: 100%;
 }
 
 .c13 {
@@ -4713,12 +4713,12 @@ exports[`TextInput TimeInput 1`] = `
         </div>
         <div
           className="c9"
+          onBlur={[Function]}
           width="full"
         >
           <div
             className="c10"
             disabled={false}
-            onBlur={[Function]}
             onClick={[Function]}
             onKeyDown={[Function]}
             onPointerDown={[Function]}

--- a/packages/core/src/Paper/index.tsx
+++ b/packages/core/src/Paper/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import styled, { css } from 'styled-components'
 import { shape, spacing } from '../designparams'
 
@@ -46,13 +46,11 @@ interface IPaperProps extends BaseProps {
   readonly space?: boolean
 }
 
-export const Paper: React.FC<IPaperProps> = ({
-  square = false,
-  space = false,
-  children,
-  ...props
-}) => (
-  <PaperDiv square={square} space={space} {...props}>
-    {children}
-  </PaperDiv>
+/* eslint-disable-next-line react/display-name */
+export const Paper = forwardRef<BaseElement, IPaperProps>(
+  ({ square = false, space = false, children, ...props }, ref) => (
+    <PaperDiv square={square} space={space} {...props} ref={ref}>
+      {children}
+    </PaperDiv>
+  )
 )

--- a/packages/core/src/Select/BaseSelectSelector.tsx
+++ b/packages/core/src/Select/BaseSelectSelector.tsx
@@ -1,0 +1,180 @@
+import React from 'react'
+import styled, { css, useTheme } from 'styled-components'
+
+import { Icon } from '../Icon'
+import { ArrowDownIcon, ArrowUpIcon } from './icons'
+import { componentSize, shape, spacing, opacity } from '..'
+
+export type SelectVariant = 'filled' | 'transparent' | 'framed'
+
+interface SelectInputProps {
+  readonly compact: boolean
+  readonly variant: SelectVariant
+  readonly hasError: boolean
+  readonly openedFocus: boolean
+  readonly visibleFocus: boolean
+  readonly disabled: boolean
+}
+
+export const SelectInsideContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  height: 100%;
+  width: 100%;
+`
+
+const SelectInput = styled.div<SelectInputProps>`
+  display: flex;
+  align-items: center;
+  min-height: ${({ compact }) =>
+    compact ? componentSize.small : componentSize.medium};
+  color: ${({ theme }) => theme.color.text01()};
+
+  background-color: ${({ variant, theme }) =>
+    variant === 'filled' || variant === 'framed'
+      ? theme.color.background02()
+      : 'transparent'};
+
+  padding: 2px;
+  border: 0 solid transparent;
+  border-radius: ${shape.radius.medium};
+
+  ${({ variant, theme }) =>
+    variant === 'framed'
+      ? css`
+          padding: 1px;
+          border: 1px solid ${theme.color.element01()};
+        `
+      : undefined}
+
+  font-family: ${({ theme }) => theme.font.family};
+  font-size: ${({ theme }) => theme.font.size.regular};
+  line-height: ${({ theme }) => theme.font.lineHeight.large};
+  text-align: left;
+  cursor: pointer;
+
+  ${SelectInsideContainer} {
+    padding: ${({ compact }) =>
+      compact
+        ? `0 ${spacing.small} 0 ${spacing.medium}`
+        : `0 ${spacing.medium}`};
+  }
+
+  > div > span > svg {
+    width: 100%;
+    height: 100%;
+    cursor: pointer;
+    background-color: transparent;
+    fill: ${({ theme }) => theme.color.element01()};
+  }
+
+  &:hover {
+    background-color: ${({ variant, theme }) =>
+      variant === 'filled' || variant === 'framed'
+        ? theme.color.background01()
+        : theme.color.background02()};
+
+    ${({ variant, theme }) =>
+      variant === 'framed'
+        ? css`
+            padding: 0;
+            border: 2px solid ${theme.color.element01()};
+          `
+        : undefined}
+  }
+
+  &:focus {
+    outline: none;
+
+    ${({ openedFocus, visibleFocus, variant, theme }) =>
+      openedFocus
+        ? css`
+            background-color: ${theme.color.background01()};
+            border: none;
+            padding: 2px;
+          `
+        : visibleFocus
+        ? css`
+            background-color: ${variant === 'filled' || variant === 'framed'
+              ? theme.color.background01()
+              : 'transparent'};
+            border: 2px solid ${theme.color.textPrimary()};
+            padding: 0;
+          `
+        : undefined}
+  }
+
+  &:active {
+    background-color: ${({ theme }) => theme.color.background01()};
+    border: none;
+    padding: 2px;
+  }
+
+  ${({ disabled }) =>
+    disabled
+      ? css`
+          opacity: ${opacity[48]};
+          pointer-events: none;
+        `
+      : undefined}
+
+  ${({ theme, hasError }) =>
+    hasError
+      ? css`
+          &,
+          &:hover,
+          &:focus {
+            background-color: ${theme.color.backgroundError()};
+            border-color: ${theme.color.elementError()};
+          }
+        `
+      : undefined};
+`
+
+export interface BaseSelectSelectorProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  readonly onToggleOpen: React.MouseEventHandler
+  readonly open: boolean
+  readonly compact?: boolean
+  readonly disabled?: boolean
+  readonly variant?: SelectVariant
+  readonly hasError?: boolean
+  readonly visibleFocus?: boolean
+}
+
+export const BaseSelectSelector: React.FC<BaseSelectSelectorProps> = ({
+  onToggleOpen,
+  open,
+  children,
+  compact: compactFromProps,
+  disabled = false,
+  variant = 'filled',
+  hasError = false,
+  visibleFocus = false,
+  ...props
+}) => {
+  const { compact: compactFromTheme } = useTheme()
+  const compact = compactFromProps ?? compactFromTheme
+
+  return (
+    <SelectInput
+      role="button"
+      tabIndex={0}
+      onClick={onToggleOpen}
+      compact={compact}
+      disabled={disabled}
+      variant={variant}
+      openedFocus={open}
+      visibleFocus={visibleFocus}
+      hasError={hasError}
+      {...props}
+    >
+      <SelectInsideContainer>
+        {children}
+        <Icon icon={open ? ArrowUpIcon : ArrowDownIcon} />
+      </SelectInsideContainer>
+    </SelectInput>
+  )
+}

--- a/packages/core/src/Select/__snapshots__/MultiSelect.test.tsx.snap
+++ b/packages/core/src/Select/__snapshots__/MultiSelect.test.tsx.snap
@@ -97,6 +97,41 @@ exports[`Select Direction 1`] = `
   z-index: 1;
 }
 
+.c8 {
+  position: relative;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  height: 24px;
+  width: -webkit-min-content;
+  width: -moz-min-content;
+  width: min-content;
+  min-width: 32px;
+  max-width: 100%;
+  padding: 0 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  overflow: hidden;
+  border-radius: 2px;
+  color: rgb(41,41,41);
+  background-color: rgb(240,240,240);
+}
+
+.c13 {
+  -webkit-flex: 0 0 min-content;
+  -ms-flex: 0 0 min-content;
+  flex: 0 0 min-content;
+  margin-left: 4px;
+}
+
 .c5 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -114,10 +149,6 @@ exports[`Select Direction 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   height: 100%;
-  width: 100%;
-}
-
-.c2 {
   width: 100%;
 }
 
@@ -172,39 +203,8 @@ exports[`Select Direction 1`] = `
   padding: 2px;
 }
 
-.c8 {
-  position: relative;
-  box-sizing: border-box;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  height: 24px;
-  width: -webkit-min-content;
-  width: -moz-min-content;
-  width: min-content;
-  min-width: 32px;
-  max-width: 100%;
-  padding: 0 8px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  overflow: hidden;
-  border-radius: 2px;
-  color: rgb(41,41,41);
-  background-color: rgb(240,240,240);
-}
-
-.c13 {
-  -webkit-flex: 0 0 min-content;
-  -ms-flex: 0 0 min-content;
-  flex: 0 0 min-content;
-  margin-left: 4px;
+.c2 {
+  width: 100%;
 }
 
 .c9 {
@@ -277,12 +277,12 @@ exports[`Select Direction 1`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -496,6 +496,41 @@ exports[`Select Direction 2`] = `
   z-index: 1;
 }
 
+.c8 {
+  position: relative;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  height: 24px;
+  width: -webkit-min-content;
+  width: -moz-min-content;
+  width: min-content;
+  min-width: 32px;
+  max-width: 100%;
+  padding: 0 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  overflow: hidden;
+  border-radius: 2px;
+  color: rgb(41,41,41);
+  background-color: rgb(240,240,240);
+}
+
+.c13 {
+  -webkit-flex: 0 0 min-content;
+  -ms-flex: 0 0 min-content;
+  flex: 0 0 min-content;
+  margin-left: 4px;
+}
+
 .c5 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -513,10 +548,6 @@ exports[`Select Direction 2`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   height: 100%;
-  width: 100%;
-}
-
-.c2 {
   width: 100%;
 }
 
@@ -571,39 +602,8 @@ exports[`Select Direction 2`] = `
   padding: 2px;
 }
 
-.c8 {
-  position: relative;
-  box-sizing: border-box;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  height: 24px;
-  width: -webkit-min-content;
-  width: -moz-min-content;
-  width: min-content;
-  min-width: 32px;
-  max-width: 100%;
-  padding: 0 8px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  overflow: hidden;
-  border-radius: 2px;
-  color: rgb(41,41,41);
-  background-color: rgb(240,240,240);
-}
-
-.c13 {
-  -webkit-flex: 0 0 min-content;
-  -ms-flex: 0 0 min-content;
-  flex: 0 0 min-content;
-  margin-left: 4px;
+.c2 {
+  width: 100%;
 }
 
 .c9 {
@@ -676,12 +676,12 @@ exports[`Select Direction 2`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -895,6 +895,41 @@ exports[`Select Other 1`] = `
   z-index: 1;
 }
 
+.c8 {
+  position: relative;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  height: 24px;
+  width: -webkit-min-content;
+  width: -moz-min-content;
+  width: min-content;
+  min-width: 32px;
+  max-width: 100%;
+  padding: 0 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  overflow: hidden;
+  border-radius: 2px;
+  color: rgb(41,41,41);
+  background-color: rgb(240,240,240);
+}
+
+.c13 {
+  -webkit-flex: 0 0 min-content;
+  -ms-flex: 0 0 min-content;
+  flex: 0 0 min-content;
+  margin-left: 4px;
+}
+
 .c5 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -912,10 +947,6 @@ exports[`Select Other 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   height: 100%;
-  width: 100%;
-}
-
-.c2 {
   width: 100%;
 }
 
@@ -977,39 +1008,8 @@ exports[`Select Other 1`] = `
   border-color: rgb(211,47,47);
 }
 
-.c8 {
-  position: relative;
-  box-sizing: border-box;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  height: 24px;
-  width: -webkit-min-content;
-  width: -moz-min-content;
-  width: min-content;
-  min-width: 32px;
-  max-width: 100%;
-  padding: 0 8px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  overflow: hidden;
-  border-radius: 2px;
-  color: rgb(41,41,41);
-  background-color: rgb(240,240,240);
-}
-
-.c13 {
-  -webkit-flex: 0 0 min-content;
-  -ms-flex: 0 0 min-content;
-  flex: 0 0 min-content;
-  margin-left: 4px;
+.c2 {
+  width: 100%;
 }
 
 .c9 {
@@ -1082,12 +1082,12 @@ exports[`Select Other 1`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -1301,6 +1301,41 @@ exports[`Select Other 2`] = `
   z-index: 1;
 }
 
+.c8 {
+  position: relative;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  height: 24px;
+  width: -webkit-min-content;
+  width: -moz-min-content;
+  width: min-content;
+  min-width: 32px;
+  max-width: 100%;
+  padding: 0 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  overflow: hidden;
+  border-radius: 2px;
+  color: rgb(41,41,41);
+  background-color: rgb(240,240,240);
+}
+
+.c13 {
+  -webkit-flex: 0 0 min-content;
+  -ms-flex: 0 0 min-content;
+  flex: 0 0 min-content;
+  margin-left: 4px;
+}
+
 .c5 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1318,10 +1353,6 @@ exports[`Select Other 2`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   height: 100%;
-  width: 100%;
-}
-
-.c2 {
   width: 100%;
 }
 
@@ -1382,39 +1413,8 @@ exports[`Select Other 2`] = `
   padding: 2px;
 }
 
-.c8 {
-  position: relative;
-  box-sizing: border-box;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  height: 24px;
-  width: -webkit-min-content;
-  width: -moz-min-content;
-  width: min-content;
-  min-width: 32px;
-  max-width: 100%;
-  padding: 0 8px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  overflow: hidden;
-  border-radius: 2px;
-  color: rgb(41,41,41);
-  background-color: rgb(240,240,240);
-}
-
-.c13 {
-  -webkit-flex: 0 0 min-content;
-  -ms-flex: 0 0 min-content;
-  flex: 0 0 min-content;
-  margin-left: 4px;
+.c2 {
+  width: 100%;
 }
 
 .c9 {
@@ -1487,12 +1487,12 @@ exports[`Select Other 2`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={true}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -1706,6 +1706,41 @@ exports[`Select Width 1`] = `
   z-index: 1;
 }
 
+.c8 {
+  position: relative;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  height: 24px;
+  width: -webkit-min-content;
+  width: -moz-min-content;
+  width: min-content;
+  min-width: 32px;
+  max-width: 100%;
+  padding: 0 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  overflow: hidden;
+  border-radius: 2px;
+  color: rgb(41,41,41);
+  background-color: rgb(240,240,240);
+}
+
+.c13 {
+  -webkit-flex: 0 0 min-content;
+  -ms-flex: 0 0 min-content;
+  flex: 0 0 min-content;
+  margin-left: 4px;
+}
+
 .c5 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1723,10 +1758,6 @@ exports[`Select Width 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   height: 100%;
-  width: 100%;
-}
-
-.c2 {
   width: 100%;
 }
 
@@ -1781,39 +1812,8 @@ exports[`Select Width 1`] = `
   padding: 2px;
 }
 
-.c8 {
-  position: relative;
-  box-sizing: border-box;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  height: 24px;
-  width: -webkit-min-content;
-  width: -moz-min-content;
-  width: min-content;
-  min-width: 32px;
-  max-width: 100%;
-  padding: 0 8px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  overflow: hidden;
-  border-radius: 2px;
-  color: rgb(41,41,41);
-  background-color: rgb(240,240,240);
-}
-
-.c13 {
-  -webkit-flex: 0 0 min-content;
-  -ms-flex: 0 0 min-content;
-  flex: 0 0 min-content;
-  margin-left: 4px;
+.c2 {
+  width: 100%;
 }
 
 .c9 {
@@ -1886,12 +1886,12 @@ exports[`Select Width 1`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -2105,6 +2105,41 @@ exports[`Select Width 2`] = `
   z-index: 1;
 }
 
+.c8 {
+  position: relative;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  height: 24px;
+  width: -webkit-min-content;
+  width: -moz-min-content;
+  width: min-content;
+  min-width: 32px;
+  max-width: 100%;
+  padding: 0 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  overflow: hidden;
+  border-radius: 2px;
+  color: rgb(41,41,41);
+  background-color: rgb(240,240,240);
+}
+
+.c13 {
+  -webkit-flex: 0 0 min-content;
+  -ms-flex: 0 0 min-content;
+  flex: 0 0 min-content;
+  margin-left: 4px;
+}
+
 .c5 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -2122,10 +2157,6 @@ exports[`Select Width 2`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   height: 100%;
-  width: 100%;
-}
-
-.c2 {
   width: 100%;
 }
 
@@ -2180,39 +2211,8 @@ exports[`Select Width 2`] = `
   padding: 2px;
 }
 
-.c8 {
-  position: relative;
-  box-sizing: border-box;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  height: 24px;
-  width: -webkit-min-content;
-  width: -moz-min-content;
-  width: min-content;
-  min-width: 32px;
-  max-width: 100%;
-  padding: 0 8px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  overflow: hidden;
-  border-radius: 2px;
-  color: rgb(41,41,41);
-  background-color: rgb(240,240,240);
-}
-
-.c13 {
-  -webkit-flex: 0 0 min-content;
-  -ms-flex: 0 0 min-content;
-  flex: 0 0 min-content;
-  margin-left: 4px;
+.c2 {
+  width: 100%;
 }
 
 .c9 {
@@ -2285,12 +2285,12 @@ exports[`Select Width 2`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -2536,6 +2536,41 @@ exports[`Select Width 3`] = `
   z-index: 1;
 }
 
+.c8 {
+  position: relative;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  height: 24px;
+  width: -webkit-min-content;
+  width: -moz-min-content;
+  width: min-content;
+  min-width: 32px;
+  max-width: 100%;
+  padding: 0 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  overflow: hidden;
+  border-radius: 2px;
+  color: rgb(41,41,41);
+  background-color: rgb(240,240,240);
+}
+
+.c13 {
+  -webkit-flex: 0 0 min-content;
+  -ms-flex: 0 0 min-content;
+  flex: 0 0 min-content;
+  margin-left: 4px;
+}
+
 .c5 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -2553,10 +2588,6 @@ exports[`Select Width 3`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   height: 100%;
-  width: 100%;
-}
-
-.c2 {
   width: 100%;
 }
 
@@ -2611,39 +2642,8 @@ exports[`Select Width 3`] = `
   padding: 2px;
 }
 
-.c8 {
-  position: relative;
-  box-sizing: border-box;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  height: 24px;
-  width: -webkit-min-content;
-  width: -moz-min-content;
-  width: min-content;
-  min-width: 32px;
-  max-width: 100%;
-  padding: 0 8px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  overflow: hidden;
-  border-radius: 2px;
-  color: rgb(41,41,41);
-  background-color: rgb(240,240,240);
-}
-
-.c13 {
-  -webkit-flex: 0 0 min-content;
-  -ms-flex: 0 0 min-content;
-  flex: 0 0 min-content;
-  margin-left: 4px;
+.c2 {
+  width: 100%;
 }
 
 .c9 {
@@ -2716,12 +2716,12 @@ exports[`Select Width 3`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}

--- a/packages/core/src/Select/__snapshots__/SearchSelect.test.tsx.snap
+++ b/packages/core/src/Select/__snapshots__/SearchSelect.test.tsx.snap
@@ -70,10 +70,6 @@ exports[`Select Direction 1`] = `
   width: 100%;
 }
 
-.c2 {
-  width: 100%;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -125,6 +121,10 @@ exports[`Select Direction 1`] = `
   padding: 2px;
 }
 
+.c2 {
+  width: 100%;
+}
+
 .c6 {
   font-family: Open Sans,Helvetica,arial,sans-serif;
   font-size: 13px;
@@ -167,12 +167,12 @@ exports[`Select Direction 1`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -295,10 +295,6 @@ exports[`Select Direction 2`] = `
   width: 100%;
 }
 
-.c2 {
-  width: 100%;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -350,6 +346,10 @@ exports[`Select Direction 2`] = `
   padding: 2px;
 }
 
+.c2 {
+  width: 100%;
+}
+
 .c6 {
   font-family: Open Sans,Helvetica,arial,sans-serif;
   font-size: 13px;
@@ -392,12 +392,12 @@ exports[`Select Direction 2`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -520,10 +520,6 @@ exports[`Select Other 1`] = `
   width: 100%;
 }
 
-.c2 {
-  width: 100%;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -582,6 +578,10 @@ exports[`Select Other 1`] = `
   border-color: rgb(211,47,47);
 }
 
+.c2 {
+  width: 100%;
+}
+
 .c6 {
   font-family: Open Sans,Helvetica,arial,sans-serif;
   font-size: 13px;
@@ -624,12 +624,12 @@ exports[`Select Other 1`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -752,10 +752,6 @@ exports[`Select Other 2`] = `
   width: 100%;
 }
 
-.c2 {
-  width: 100%;
-}
-
 .c10 .c4 {
   padding: 0 8px;
 }
@@ -813,6 +809,10 @@ exports[`Select Other 2`] = `
   padding: 2px;
 }
 
+.c2 {
+  width: 100%;
+}
+
 .c6 {
   font-family: Open Sans,Helvetica,arial,sans-serif;
   font-size: 13px;
@@ -855,12 +855,12 @@ exports[`Select Other 2`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={true}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -983,10 +983,6 @@ exports[`Select SelectMarker 1`] = `
   width: 100%;
 }
 
-.c2 {
-  width: 100%;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1038,6 +1034,10 @@ exports[`Select SelectMarker 1`] = `
   padding: 2px;
 }
 
+.c2 {
+  width: 100%;
+}
+
 .c6 {
   font-family: Open Sans,Helvetica,arial,sans-serif;
   font-size: 13px;
@@ -1080,12 +1080,12 @@ exports[`Select SelectMarker 1`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -1208,10 +1208,6 @@ exports[`Select SelectMarker 2`] = `
   width: 100%;
 }
 
-.c2 {
-  width: 100%;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1263,6 +1259,10 @@ exports[`Select SelectMarker 2`] = `
   padding: 2px;
 }
 
+.c2 {
+  width: 100%;
+}
+
 .c6 {
   font-family: Open Sans,Helvetica,arial,sans-serif;
   font-size: 13px;
@@ -1305,12 +1305,12 @@ exports[`Select SelectMarker 2`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -1433,10 +1433,6 @@ exports[`Select Width 1`] = `
   width: 100%;
 }
 
-.c2 {
-  width: 100%;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1488,6 +1484,10 @@ exports[`Select Width 1`] = `
   padding: 2px;
 }
 
+.c2 {
+  width: 100%;
+}
+
 .c6 {
   font-family: Open Sans,Helvetica,arial,sans-serif;
   font-size: 13px;
@@ -1530,12 +1530,12 @@ exports[`Select Width 1`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -1658,10 +1658,6 @@ exports[`Select Width 2`] = `
   width: 100%;
 }
 
-.c2 {
-  width: 100%;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1713,6 +1709,10 @@ exports[`Select Width 2`] = `
   padding: 2px;
 }
 
+.c2 {
+  width: 100%;
+}
+
 .c6 {
   font-family: Open Sans,Helvetica,arial,sans-serif;
   font-size: 13px;
@@ -1755,12 +1755,12 @@ exports[`Select Width 2`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -1883,10 +1883,6 @@ exports[`Select Width 3`] = `
   width: 100%;
 }
 
-.c2 {
-  width: 100%;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1938,6 +1934,10 @@ exports[`Select Width 3`] = `
   padding: 2px;
 }
 
+.c2 {
+  width: 100%;
+}
+
 .c6 {
   font-family: Open Sans,Helvetica,arial,sans-serif;
   font-size: 13px;
@@ -1980,12 +1980,12 @@ exports[`Select Width 3`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}

--- a/packages/core/src/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/core/src/Select/__snapshots__/Select.test.tsx.snap
@@ -70,10 +70,6 @@ exports[`Select Compact 1`] = `
   width: 100%;
 }
 
-.c2 {
-  width: 100%;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -125,6 +121,10 @@ exports[`Select Compact 1`] = `
   padding: 2px;
 }
 
+.c2 {
+  width: 100%;
+}
+
 .c6 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -145,12 +145,12 @@ exports[`Select Compact 1`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -273,10 +273,6 @@ exports[`Select Compact 2`] = `
   width: 100%;
 }
 
-.c2 {
-  width: 100%;
-}
-
 .c10 .c4 {
   padding: 0 4px 0 8px;
 }
@@ -332,6 +328,10 @@ exports[`Select Compact 2`] = `
   padding: 2px;
 }
 
+.c2 {
+  width: 100%;
+}
+
 .c6 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -352,12 +352,12 @@ exports[`Select Compact 2`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -480,10 +480,6 @@ exports[`Select Direction 1`] = `
   width: 100%;
 }
 
-.c2 {
-  width: 100%;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -535,6 +531,10 @@ exports[`Select Direction 1`] = `
   padding: 2px;
 }
 
+.c2 {
+  width: 100%;
+}
+
 .c6 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -555,12 +555,12 @@ exports[`Select Direction 1`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -683,10 +683,6 @@ exports[`Select Direction 2`] = `
   width: 100%;
 }
 
-.c2 {
-  width: 100%;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -738,6 +734,10 @@ exports[`Select Direction 2`] = `
   padding: 2px;
 }
 
+.c2 {
+  width: 100%;
+}
+
 .c6 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -758,12 +758,12 @@ exports[`Select Direction 2`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -886,10 +886,6 @@ exports[`Select Other 1`] = `
   width: 100%;
 }
 
-.c2 {
-  width: 100%;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -948,6 +944,10 @@ exports[`Select Other 1`] = `
   border-color: rgb(211,47,47);
 }
 
+.c2 {
+  width: 100%;
+}
+
 .c6 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -968,12 +968,12 @@ exports[`Select Other 1`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -1096,10 +1096,6 @@ exports[`Select Other 2`] = `
   width: 100%;
 }
 
-.c2 {
-  width: 100%;
-}
-
 .c10 .c4 {
   padding: 0 8px;
 }
@@ -1157,6 +1153,10 @@ exports[`Select Other 2`] = `
   padding: 2px;
 }
 
+.c2 {
+  width: 100%;
+}
+
 .c6 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1177,12 +1177,12 @@ exports[`Select Other 2`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={true}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -1305,10 +1305,6 @@ exports[`Select SelectMarker 1`] = `
   width: 100%;
 }
 
-.c2 {
-  width: 100%;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1360,6 +1356,10 @@ exports[`Select SelectMarker 1`] = `
   padding: 2px;
 }
 
+.c2 {
+  width: 100%;
+}
+
 .c6 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1380,12 +1380,12 @@ exports[`Select SelectMarker 1`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -1508,10 +1508,6 @@ exports[`Select SelectMarker 2`] = `
   width: 100%;
 }
 
-.c2 {
-  width: 100%;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1563,6 +1559,10 @@ exports[`Select SelectMarker 2`] = `
   padding: 2px;
 }
 
+.c2 {
+  width: 100%;
+}
+
 .c6 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1583,12 +1583,12 @@ exports[`Select SelectMarker 2`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -1711,10 +1711,6 @@ exports[`Select Variant 1`] = `
   width: 100%;
 }
 
-.c2 {
-  width: 100%;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1766,6 +1762,10 @@ exports[`Select Variant 1`] = `
   padding: 2px;
 }
 
+.c2 {
+  width: 100%;
+}
+
 .c6 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1786,12 +1786,12 @@ exports[`Select Variant 1`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -1914,10 +1914,6 @@ exports[`Select Variant 2`] = `
   width: 100%;
 }
 
-.c2 {
-  width: 100%;
-}
-
 .c10 .c4 {
   padding: 0 8px;
 }
@@ -1973,6 +1969,10 @@ exports[`Select Variant 2`] = `
   padding: 2px;
 }
 
+.c2 {
+  width: 100%;
+}
+
 .c6 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1993,12 +1993,12 @@ exports[`Select Variant 2`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -2121,10 +2121,6 @@ exports[`Select Variant 3`] = `
   width: 100%;
 }
 
-.c2 {
-  width: 100%;
-}
-
 .c10 .c4 {
   padding: 0 8px;
 }
@@ -2188,6 +2184,10 @@ exports[`Select Variant 3`] = `
   padding: 2px;
 }
 
+.c2 {
+  width: 100%;
+}
+
 .c6 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2208,12 +2208,12 @@ exports[`Select Variant 3`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -2336,10 +2336,6 @@ exports[`Select Width 1`] = `
   width: 100%;
 }
 
-.c2 {
-  width: 160px;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -2391,6 +2387,10 @@ exports[`Select Width 1`] = `
   padding: 2px;
 }
 
+.c2 {
+  width: 160px;
+}
+
 .c6 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2411,12 +2411,12 @@ exports[`Select Width 1`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="small"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -2539,10 +2539,6 @@ exports[`Select Width 2`] = `
   width: 100%;
 }
 
-.c2 {
-  width: 220px;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -2594,6 +2590,10 @@ exports[`Select Width 2`] = `
   padding: 2px;
 }
 
+.c2 {
+  width: 220px;
+}
+
 .c6 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2614,12 +2614,12 @@ exports[`Select Width 2`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="medium"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -2742,10 +2742,6 @@ exports[`Select Width 3`] = `
   width: 100%;
 }
 
-.c2 {
-  width: 300px;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -2797,6 +2793,10 @@ exports[`Select Width 3`] = `
   padding: 2px;
 }
 
+.c2 {
+  width: 300px;
+}
+
 .c6 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2817,12 +2817,12 @@ exports[`Select Width 3`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="large"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}
@@ -2945,10 +2945,6 @@ exports[`Select Width 4`] = `
   width: 100%;
 }
 
-.c2 {
-  width: 100%;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -3000,6 +2996,10 @@ exports[`Select Width 4`] = `
   padding: 2px;
 }
 
+.c2 {
+  width: 100%;
+}
+
 .c6 {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -3020,12 +3020,12 @@ exports[`Select Width 4`] = `
     >
       <div
         className="c2"
+        onBlur={[Function]}
         width="full"
       >
         <div
           className="c3"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onKeyDown={[Function]}
           onPointerDown={[Function]}

--- a/packages/core/src/Select/index.ts
+++ b/packages/core/src/Select/index.ts
@@ -1,3 +1,4 @@
+export * from './BaseSelectSelector'
 export * from './BaseSelect'
 export * from './Select'
 export * from './MultiSelect'

--- a/packages/ui-tests/src/coreComponents/Select.spec.ts
+++ b/packages/ui-tests/src/coreComponents/Select.spec.ts
@@ -4,7 +4,8 @@ context('Select', () => {
   const popOverEl = '[class^=PopOver__]'
   const popOverSelectItem = '[class^=BaseSelect__SelectItem]'
   const multiSelectChip = '[class^=MultiSelect__ChipContainer]'
-  const selectSelectedItem = '[class^=BaseSelect__SelectInsideContainer]'
+  const selectSelectedItem =
+    '[class^=BaseSelectSelector__SelectInsideContainer]'
   const searchSelectInput = '[class^=SearchSelect__InputNative]'
 
   const options = [


### PR DESCRIPTION
The selector itself could be reused to make other types of selects such
as a larger area, or a grid of things. This splits out the selector part
from BaseSelect into BaseSelectSelector.

In addition this adds a forwardRef to Paper so it can be reused in
dropdowns.