### PR TITLE
docs: change width of docs content

### DIFF
--- a/packages/docs/src/index.tsx
+++ b/packages/docs/src/index.tsx
@@ -84,7 +84,7 @@ const Aside = styled.aside`
 `
 
 const Main = styled.main`
-  max-width: 900px;
+  max-width: 1200px;
   margin: 0 auto;
   background-color: ${({ theme }) => theme.color.background00()};
   padding: ${spacing.extraLarge};


### PR DESCRIPTION
Changes the width of the docs content from 900px to 1200px. This improves the readability of the different playgrounds.

900px

![prc_900px](https://user-images.githubusercontent.com/7765599/106283473-43cffd80-6242-11eb-907c-45dbe5e44922.png)

1200px

![prc_1200px](https://user-images.githubusercontent.com/7765599/106283489-492d4800-6242-11eb-99ca-0b157d68b6ac.png)
