### PR TITLE
feat(card)!: refactors `CardHeader` to use only `ReactNode`

### DIFF
--- a/packages/core/src/Card/CardHeader.tsx
+++ b/packages/core/src/Card/CardHeader.tsx
@@ -1,29 +1,19 @@
 import React, { useCallback } from 'react'
 import styled, { css } from 'styled-components'
-import { MoreVertIcon } from 'practical-react-components-icons'
 
 import { CARD_PADDING } from './padding'
-import { Typography } from '../Typography'
 import { Arrow } from '../Expandable'
-import { Menu, IMenuItem } from '../Menu'
+import { Typography } from '../Typography'
 import { spacing } from '../designparams'
 
 export type CardHeaderHeightType = 'small' | 'normal' | 'large'
 type BaseElement = HTMLDivElement
 type BaseProps = React.HTMLAttributes<BaseElement>
 
-const HEADER_HEIGHT = {
-  small: '40px',
-  normal: '48px',
-  large: '60px',
-}
-
-const ICON_CONTAINER_WIDTH = '72px'
-
 /**
  * Empty header with just a bottom border
  */
-export const EmptyHeader = styled.div`
+export const BaseHeader = styled.div`
   flex: none;
   box-sizing: border-box;
   width: 100%;
@@ -32,37 +22,14 @@ export const EmptyHeader = styled.div`
   border-bottom: 1px solid ${({ theme }) => theme.color.element12()};
 `
 
-interface ITitleHeaderProps {
-  readonly height: CardHeaderHeightType
-  readonly hasIcon: boolean
-}
-
-const TitleHeader = styled(EmptyHeader)<ITitleHeaderProps>`
-  position: relative; /* This is for special icon like corner triangle */
+const TitleHeader = styled(BaseHeader)`
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
   align-items: center;
-  height: ${({ height }) => HEADER_HEIGHT[height]};
   cursor: default;
-
-  ${({ hasIcon }) =>
-    hasIcon
-      ? css`
-          padding-right: ${CARD_PADDING};
-        `
-      : css`
-          padding: 0 ${CARD_PADDING};
-        `}
-`
-
-const HeaderIcon = styled.div`
-  width: ${ICON_CONTAINER_WIDTH};
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: ${({ theme }) => theme.color.element11()};
+  height: auto;
+  padding: ${spacing.medium} ${CARD_PADDING};
 `
 
 const TitleContainer = styled.div`
@@ -74,95 +41,36 @@ const TitleContainer = styled.div`
   text-overflow: ellipsis;
 `
 
-interface ITabsHeaderContainerProps extends Pick<ITitleHeaderProps, 'height'> {}
+export const CardHeaderTypography = styled(Typography).attrs({
+  variant: 'card-title',
+})``
 
-/* Header container for inside tabs */
-export const TabsHeaderContainer = styled(
-  EmptyHeader
-)<ITabsHeaderContainerProps>`
-  display: flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
-  align-items: center;
-  height: ${({ height }) => HEADER_HEIGHT[height]};
-  padding: 0 ${spacing.large};
-`
+export const CardSubHeaderTypography = styled(Typography).attrs({
+  variant: 'caption',
+})``
 
-export interface ICardHeaderProps extends BaseProps {
+export interface CardHeaderProps extends BaseProps {
   /**
-   * Label that shows inside Card Header
+   * `class` to be passed to the component.
    */
-  readonly header: string
-  /**
-   * Small label that shows inside Card Header under header label
-   */
-  readonly subhead?: string
-  /**
-   * Header height
-   *
-   * Default: `normal`
-   */
-  readonly height?: CardHeaderHeightType
-  /**
-   * Optional icon
-   */
-  readonly icon?: React.ReactNode
-  /**
-   * Menu items that shows inside menu
-   */
-  readonly menu?: ReadonlyArray<IMenuItem>
-  /**
-   * if `true` return a header for inside tabs.
-   *
-   * Default: `false`
-   */
-  readonly tab?: boolean
+  readonly className?: string
 }
 
-export const CardHeader: React.FC<ICardHeaderProps> = ({
-  header,
-  subhead,
-  height = 'normal',
-  icon,
-  menu,
-  tab = false,
+export const CardHeader: React.FC<CardHeaderProps> = ({
   children,
   ...props
-}) => {
-  const hasIcon = icon !== undefined
-
-  if (tab) {
-    return (
-      <TabsHeaderContainer height={height} {...props}>
-        {children}
-      </TabsHeaderContainer>
-    )
-  }
-
-  return (
-    <TitleHeader height={height} hasIcon={hasIcon} {...props}>
-      {icon !== undefined ? <HeaderIcon>{icon}</HeaderIcon> : undefined}
-      <TitleContainer>
-        <Typography variant="card-title">{header}</Typography>
-        <Typography variant="caption">{subhead}</Typography>
-      </TitleContainer>
-      {menu !== undefined ? (
-        <Menu icon={MoreVertIcon} items={menu} />
-      ) : undefined}
-    </TitleHeader>
-  )
-}
+}) => <TitleHeader {...props}>{children}</TitleHeader>
 
 /**
  * Expandable header
  */
 
-interface IExpandableTitleHeaderProps {
+interface ExpandableTitleHeaderProps {
   readonly expanded: boolean
   readonly disabled: boolean
 }
 
-const ExpandableTitleHeader = styled(TitleHeader)<IExpandableTitleHeaderProps>`
+const ExpandableTitleHeader = styled(TitleHeader)<ExpandableTitleHeaderProps>`
   cursor: ${({ disabled }) => (disabled ? undefined : 'pointer')};
 
   ${({ expanded }) =>
@@ -174,23 +82,19 @@ const ExpandableTitleHeader = styled(TitleHeader)<IExpandableTitleHeaderProps>`
       : undefined};
 `
 
-export interface ICardExpandableHeaderProps extends ICardHeaderProps {
+export interface CardExpandableHeaderProps extends CardHeaderProps {
   readonly disabled?: boolean
   readonly expanded?: boolean
   readonly onToggle: (expanded: boolean) => void
 }
 
-export const CardExpandableHeader: React.FC<ICardExpandableHeaderProps> = ({
-  header,
-  subhead,
-  height = 'normal',
-  icon,
+export const CardExpandableHeader: React.FC<CardExpandableHeaderProps> = ({
   disabled = false,
   expanded = false,
   onToggle,
+  children,
   ...props
 }) => {
-  const hasIcon = icon !== undefined
   const onClick = useCallback<React.MouseEventHandler<HTMLDivElement>>(() => {
     if (!disabled) {
       onToggle(!expanded)
@@ -199,18 +103,12 @@ export const CardExpandableHeader: React.FC<ICardExpandableHeaderProps> = ({
 
   return (
     <ExpandableTitleHeader
-      height={height}
       disabled={disabled}
       expanded={expanded}
       onClick={onClick}
-      hasIcon={hasIcon}
       {...props}
     >
-      {icon !== undefined ? <HeaderIcon>{icon}</HeaderIcon> : undefined}
-      <TitleContainer>
-        <Typography variant="card-title">{header}</Typography>
-        <Typography variant="caption">{subhead}</Typography>
-      </TitleContainer>
+      <TitleContainer>{children}</TitleContainer>
       <Arrow disabled={disabled} expanded={expanded} />
     </ExpandableTitleHeader>
   )

--- a/packages/docs/src/mdx/coreComponents/Card.mdx
+++ b/packages/docs/src/mdx/coreComponents/Card.mdx
@@ -6,7 +6,6 @@ export const meta = {
 
 import { useState, useCallback } from 'react'
 import styled from 'styled-components'
-
 import {
   Typography,
   Button,
@@ -27,15 +26,21 @@ import {
   TextBlock,
   Card,
   CardHeader,
+  CardHeaderTypography,
+  CardSubHeaderTypography,
   CardContent,
   CardFooter,
   CardPlainContent,
   CardExpandableHeader,
   CardTabs,
   CardFooterSpacer,
+  Menu,
 } from 'practical-react-components-core'
+import {
+  ImagePlaceholderIcon,
+  MoreVertIcon,
+} from 'practical-react-components-icons'
 
-import { ImagePlaceholderIcon } from 'practical-react-components-icons'
 import { smallParagraphFixture } from '../fixtures/paragraphs'
 
 # Card
@@ -93,6 +98,45 @@ export const OutsideHeader = styled(Typography).attrs({
   color: ${({ theme }) => theme.color.text05()};
 `
 
+export const HeaderWithMenuWrapper = styled.div`
+  display: grid;
+  grid-template-columns: 1fr auto;
+  width: 100%;
+  align-items: center;
+`
+
+export const HeaderIcon = styled(Icon)`
+  width: 72px;
+  height: 100%;
+  margin-left: -24px;
+  svg {
+    width: 24px;
+    height: 24px;
+  }
+`
+
+export const CardHeaderTabs = styled(CardHeader)`
+  padding: 0;
+  height: 48px;
+`
+
+export const CardHeaderWithTriablge = styled(CardHeader)`
+  position: relative;
+`
+
+export const HeaderTriablgeWithMenuWrapper = styled.div`
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  width: 100%;
+  align-items: center;
+  grid-gap: 16px;
+`
+
+export const ExpandableHeaderWrapper = styled.div`
+  display: grid;
+  grid-template-columns: auto 1fr;
+`
+
 export const fruitOptions = [
   { value: 'apple', label: 'Apple' },
   { value: 'banana', label: 'Banana' },
@@ -144,7 +188,9 @@ export const DemoComponent = ({}) => {
     <>
       <Wrapper>
         <Card>
-          <CardHeader header="Small height header" height="small" />
+          <CardHeader>
+            <CardHeaderTypography>Small height header</CardHeaderTypography>
+          </CardHeader>
           <CardContent>
             <Typography>Card content</Typography>
           </CardContent>
@@ -153,19 +199,24 @@ export const DemoComponent = ({}) => {
           </CardFooter>
         </Card>
         <Card>
-          <CardHeader
-            header="With menu"
-            menu={[
-              { label: 'Blue', onClick },
-              { label: 'Yellow', onClick },
-              {
-                label: 'Green',
-                onClick,
-                divider: true,
-              },
-              { label: 'White', onClick },
-            ]}
-          />
+          <CardHeader>
+            <HeaderWithMenuWrapper>
+              <CardHeaderTypography>With menu</CardHeaderTypography>
+              <Menu
+                icon={MoreVertIcon}
+                items={[
+                  { label: 'Blue', onClick },
+                  { label: 'Yellow', onClick },
+                  {
+                    label: 'Green',
+                    onClick,
+                    divider: true,
+                  },
+                  { label: 'White', onClick },
+                ]}
+              />
+            </HeaderWithMenuWrapper>
+          </CardHeader>
           <CardContent>
             <Typography variant="default-text">
               {smallParagraphFixture}
@@ -177,25 +228,9 @@ export const DemoComponent = ({}) => {
           </CardFooter>
         </Card>
         <Card>
-          <CardHeader
-            header="With image"
-            icon={<Icon icon={ImagePlaceholderIcon} />}
-          />
-          <CardContent>
-            <Typography>Card content</Typography>
-          </CardContent>
-          <CardFooter>
-            <Button onClick={onClick} label="Action 1" />
-          </CardFooter>
-        </Card>
-        <Card>
-          <CardHeader tab={true}>
-            <CardTabs
-              variant="inside"
-              options={tabs}
-              value={tab}
-              onChange={setTab}
-            />
+          <CardHeader>
+            <HeaderIcon icon={ImagePlaceholderIcon} />
+            <CardHeaderTypography>With image</CardHeaderTypography>
           </CardHeader>
           <CardContent>
             <Typography>Card content</Typography>
@@ -205,7 +240,23 @@ export const DemoComponent = ({}) => {
           </CardFooter>
         </Card>
         <Card>
-          <CardHeader tab={true} height="small">
+          <CardHeaderTabs>
+            <CardTabs
+              variant="inside"
+              options={tabs}
+              value={tab}
+              onChange={setTab}
+            />
+          </CardHeaderTabs>
+          <CardContent>
+            <Typography>Card content</Typography>
+          </CardContent>
+          <CardFooter>
+            <Button onClick={onClick} label="Action 1" />
+          </CardFooter>
+        </Card>
+        <Card>
+          <CardHeaderTabs>
             <CardTabs
               variant="inside"
               options={tabs}
@@ -213,7 +264,7 @@ export const DemoComponent = ({}) => {
               onChange={setTab}
               hasBackground={true}
             />
-          </CardHeader>
+          </CardHeaderTabs>
           <CardContent>
             <Typography>Card content</Typography>
           </CardContent>
@@ -236,25 +287,30 @@ export const DemoComponent = ({}) => {
           </Card>
         </OutsideTabsContainer>
         <Card square={false}>
-          <CardHeader
-            header="With image(s) and with menu"
-            icon={
-              <>
+          <CardHeaderWithTriablge>
+            <HeaderTriablgeWithMenuWrapper>
+              <div>
                 <Triangle />
                 <Dot />
-              </>
-            }
-            menu={[
-              { label: 'Blue', onClick },
-              { label: 'Yellow', onClick },
-              {
-                label: 'Green',
-                onClick,
-                divider: true,
-              },
-              { label: 'White', onClick },
-            ]}
-          />
+              </div>
+              <CardHeaderTypography>
+                With image(s) and with menu
+              </CardHeaderTypography>
+              <Menu
+                icon={MoreVertIcon}
+                items={[
+                  { label: 'Blue', onClick },
+                  { label: 'Yellow', onClick },
+                  {
+                    label: 'Green',
+                    onClick,
+                    divider: true,
+                  },
+                  { label: 'White', onClick },
+                ]}
+              />
+            </HeaderTriablgeWithMenuWrapper>
+          </CardHeaderWithTriablge>
           <CardContent>
             <Typography>Card content</Typography>
           </CardContent>
@@ -268,13 +324,20 @@ export const DemoComponent = ({}) => {
         </Card>
         <Card>
           <CardExpandableHeader
-            header="Expandable header"
             subhead="Sub heading"
             height="large"
             icon={<Icon icon={ImagePlaceholderIcon} size="large" />}
             expanded={isExpanded}
             onToggle={setExpanded}
-          />
+          >
+            <ExpandableHeaderWrapper>
+              <HeaderIcon icon={ImagePlaceholderIcon} />
+              <div>
+                <CardHeaderTypography>Expandable header</CardHeaderTypography>
+                <CardSubHeaderTypography>Sub heading</CardSubHeaderTypography>
+              </div>
+            </ExpandableHeaderWrapper>
+          </CardExpandableHeader>
           <FoldTransition expanded={isExpanded}>
             <CardContent>
               <Typography>Card content</Typography>

--- a/packages/ui-tests/src/coreComponents/Card.cypress.tsx
+++ b/packages/ui-tests/src/coreComponents/Card.cypress.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import {
   Card,
   CardHeader,
+  CardHeaderTypography,
   CardContent,
   CardFooter,
   Typography,
@@ -21,7 +22,9 @@ const NOOP = () => {
 
 const Test = () => (
   <Card data-cy="card">
-    <CardHeader header="Card header" />
+    <CardHeader>
+      <CardHeaderTypography>Card header</CardHeaderTypography>
+    </CardHeader>
     <CardContent>
       <Typography>Card content</Typography>
     </CardContent>


### PR DESCRIPTION
BEAKING CHANGE:
- Refactors the `CardHeader` to use only `ReactNode` in order
to allow easier placement of the content without the need
for many confusing props.
- Adds `CardHeaderTypography` component for the header text
- Adds `CardSubHeaderTypography` component for the
subheader text
- Adds examples in `.mdx` files for how to implelement
previous examples