### PR TITLE
feat(toast): custom icon for info toaster

### DIFF
--- a/packages/core/src/Toast/toastCreators.tsx
+++ b/packages/core/src/Toast/toastCreators.tsx
@@ -105,6 +105,10 @@ export interface IProgressToast extends ISimpleToast {
   }
 }
 
+export interface IInfoToast extends ISimpleToast {
+  readonly icon?: IconType
+}
+
 export type IToast = ISimpleToast | IActionToast
 
 type ToastCreator<T = IToast> = (toast: T) => IBaseToast
@@ -112,6 +116,7 @@ type ToastCreator<T = IToast> = (toast: T) => IBaseToast
 type SimpleToastCreator = ToastCreator<ISimpleToast>
 type ActionToastCreator = ToastCreator<IActionToast>
 type ProgressToastCreator = ToastCreator<IProgressToast>
+type InfoToastCreator = ToastCreator<IInfoToast>
 
 /*
  * Success toast
@@ -223,9 +228,10 @@ export const createWarningToast: SimpleToastCreator = ({
  * Info toast
  */
 
-export const createInfoToast: SimpleToastCreator = ({
+export const createInfoToast: InfoToastCreator = ({
   label,
   message,
+  icon,
   ...rest
 }) => {
   const labelComponent = (
@@ -237,9 +243,9 @@ export const createInfoToast: SimpleToastCreator = ({
       {label}
     </ToastLabel>
   )
-  const icon = (
+  const iconComponent = (
     <InfoIconColor>
-      <Icon icon={InfoIcon} />
+      <Icon icon={icon ?? InfoIcon} />
     </InfoIconColor>
   )
 
@@ -247,7 +253,7 @@ export const createInfoToast: SimpleToastCreator = ({
     message !== undefined ? <Message>{message}</Message> : undefined
 
   return {
-    icon,
+    icon: iconComponent,
     label: labelComponent,
     message: messageComponent,
     ...rest,

--- a/packages/core/src/Toast/useToasts.ts
+++ b/packages/core/src/Toast/useToasts.ts
@@ -11,6 +11,7 @@ import {
   ISimpleToast,
   IActionToast,
   IProgressToast,
+  IInfoToast,
   createSuccessToast,
   createErrorToast,
   createInfoToast,
@@ -28,6 +29,7 @@ type HideToastHandler = (id: ToastId) => void
 type SimpleToastCreator = (toast: ISimpleToast, id?: ToastId) => ToastId
 type ActionToastCreator = (toast: IActionToast, id?: ToastId) => ToastId
 type ProgressToastCreator = (toast: IProgressToast, id?: ToastId) => ToastId
+type InfoToastCreator = (toast: IInfoToast, id?: ToastId) => ToastId
 
 export interface ISimpleToastsDurations {
   readonly success?: number
@@ -43,7 +45,7 @@ export interface IToastCallbacks {
   readonly showSuccessToast: SimpleToastCreator
   readonly showErrorToast: SimpleToastCreator
   readonly showWarningToast: SimpleToastCreator
-  readonly showInfoToast: SimpleToastCreator
+  readonly showInfoToast: InfoToastCreator
   readonly showLoadingToast: SimpleToastCreator
   readonly showProgressToast: ProgressToastCreator
   readonly showActionToast: ActionToastCreator
@@ -86,7 +88,7 @@ export const useToastCallbacks = (
     [showToast, error]
   )
 
-  const showInfoToast: SimpleToastCreator = useCallback(
+  const showInfoToast: InfoToastCreator = useCallback(
     (toast, id) => showToast({ duration: info, ...createInfoToast(toast) }, id),
     [showToast, info]
   )


### PR DESCRIPTION
Adds the ability to specify a custom icon for the info toaster. If no icon is specified it will fall back to the regular info icon.

![info_toast](https://user-images.githubusercontent.com/7765599/106758741-2cbe5080-6632-11eb-8542-4c97b401bf99.png)
