### PR TITLE
feat(basemenu)!: refactors `BaseMenu` to use `ReactNode` for menu button

### DIFF
--- a/packages/core/src/Icon/index.tsx
+++ b/packages/core/src/Icon/index.tsx
@@ -49,7 +49,7 @@ export type IconType =
 
 export type IconSize = 'small' | 'medium' | 'large' | 'extraLarge'
 
-interface IconProps extends BaseProps {
+export interface IconProps extends BaseProps {
   /**
    * `class` to be passed to the component.
    */

--- a/packages/core/src/Menu/BaseMenu.tsx
+++ b/packages/core/src/Menu/BaseMenu.tsx
@@ -8,17 +8,16 @@ import React, {
 } from 'react'
 import styled, { css } from 'styled-components'
 
-import { spacing, componentSize, opacity, shape } from '../designparams'
-import { remainder } from '../utils/math'
-
-import { Icon, IconType } from '../Icon'
-import { MoreVertIcon } from 'practical-react-components-icons'
-import { PopOver, PopOverProps } from '../PopOver'
 import {
   useBoolean,
   useVisibleFocus,
   useClickOutside,
 } from 'react-hooks-shareable'
+
+import { spacing, componentSize, opacity, shape } from '../designparams'
+import { remainder } from '../utils/math'
+import { Icon } from '../Icon'
+import { PopOver, PopOverProps } from '../PopOver'
 import { useEscapeListenerStack } from '../Modal/hooks/useEscapeListenerStack'
 
 type BaseElement = HTMLDivElement
@@ -35,12 +34,24 @@ const Anchor = styled.div`
   height: fit-content;
 `
 
-const MenuIcon = styled(Icon).attrs({ className: 'sc-ButtonIcon' })`
+export const MenuButtonIconContainer = styled.div`
+  position: relative;
+  height: ${componentSize.small};
+  width: ${componentSize.small};
+  border-radius: ${shape.radius.circle};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`
+
+export const MenuButtonIcon = styled(Icon).attrs({
+  className: 'sc-ButtonIcon',
+})`
   fill: inherit;
   flex: none;
 `
 
-const MenuButtonHalo = styled.div`
+export const MenuButtonHalo = styled.div`
   position: absolute;
   top: 0;
   right: 0;
@@ -53,17 +64,15 @@ const MenuButtonHalo = styled.div`
   transition: transform 100ms;
 `
 
-const MenuNativeButton = styled.button<{ readonly visibleFocus: boolean }>`
-  position: relative;
+const MenuNativeButton = styled.button<{
+  readonly visibleFocus: boolean
+}>`
   flex: none;
-  height: ${componentSize.small};
-  width: ${componentSize.small};
-  border-radius: ${shape.radius.circle};
   min-width: unset;
   padding: unset;
   outline: none;
-  border: 2px solid transparent;
   cursor: pointer;
+  border: 0;
   &::-moz-focus-inner {
     border: 0;
   }
@@ -71,9 +80,14 @@ const MenuNativeButton = styled.button<{ readonly visibleFocus: boolean }>`
   fill: ${({ theme }) => theme.color.text04()};
   background-color: transparent;
   transition: all 200ms;
+  ${MenuButtonIconContainer} {
+    border: 2px solid transparent;
+  }
 
   &:hover {
-    border: 0 solid transparent;
+    ${MenuButtonIconContainer} {
+      border: 0 solid transparent;
+    }
     ${MenuButtonHalo} {
       background-color: ${({ theme }) => theme.color.element11(opacity[16])};
       transform: scale(1);
@@ -85,7 +99,9 @@ const MenuNativeButton = styled.button<{ readonly visibleFocus: boolean }>`
       visibleFocus
         ? css`
             &:focus {
-              border: 2px solid ${({ theme }) => theme.color.elementBorder()};
+              ${MenuButtonIconContainer} {
+                border: 2px solid ${({ theme }) => theme.color.elementBorder()};
+              }
               ${MenuButtonHalo} {
                 background-color: ${({ theme }) =>
                   theme.color.element11(opacity[16])};
@@ -178,26 +194,22 @@ interface MenuButtonProps extends BaseButtonProps {
    */
   readonly className?: string
   /**
-   * Icon that shows inside Button.
-   */
-  readonly icon: IconType
-  /**
    * The title attribute specifies extra information about an element.
    */
   readonly title?: string
 }
 
-export const MenuButton = React.forwardRef<BaseButtonElement, MenuButtonProps>(
+const MenuButton = React.forwardRef<BaseButtonElement, MenuButtonProps>(
   (
     {
       disabled,
       name,
       onClick,
       className,
-      icon,
       onPointerDown,
       onPointerUp,
       onFocus,
+      children,
       ...props
     },
     ref
@@ -249,8 +261,7 @@ export const MenuButton = React.forwardRef<BaseButtonElement, MenuButtonProps>(
         visibleFocus={visibleFocus}
         {...props}
       >
-        <MenuIcon icon={icon} />
-        <MenuButtonHalo />
+        {children}
       </MenuNativeButton>
     )
   }
@@ -378,9 +389,9 @@ const BaseItem: React.FunctionComponent<BaseItemProps> = ({
 
 export interface BaseMenuProps extends Omit<PopOverProps, 'anchorEl'> {
   /**
-   * The icon element.
+   * React element that will appear as menu button
    */
-  readonly icon?: IconType
+  readonly button: ReactNode
   /**
    * Aligns the menu either left or right.
    */
@@ -403,7 +414,7 @@ export interface BaseMenuProps extends Omit<PopOverProps, 'anchorEl'> {
  */
 export const BaseMenu = memo<BaseMenuProps>(
   ({
-    icon = MoreVertIcon,
+    button,
     align = 'left',
     disabled = false,
     components,
@@ -537,7 +548,9 @@ export const BaseMenu = memo<BaseMenuProps>(
         onBlur={handleBlur}
         {...props}
       >
-        <MenuButton icon={icon} onClick={mouseToggleMenu} disabled={disabled} />
+        <MenuButton onClick={mouseToggleMenu} disabled={disabled}>
+          {button}
+        </MenuButton>
         {menuVisible ? (
           <PopOver
             horizontalPosition={align}

--- a/packages/core/src/Menu/Menu.tsx
+++ b/packages/core/src/Menu/Menu.tsx
@@ -1,10 +1,19 @@
 import React, { memo, useMemo } from 'react'
 import styled, { css, useTheme } from 'styled-components'
 
+import { MoreVertIcon } from 'practical-react-components-icons'
+
 import { componentSize, spacing } from '../designparams'
 import { Typography } from '../Typography'
 import { Icon, IconType } from '../Icon'
-import { BaseMenu, BaseItemProps, BaseMenuProps } from './BaseMenu'
+import {
+  BaseMenu,
+  BaseItemProps,
+  BaseMenuProps,
+  MenuButtonIcon,
+  MenuButtonHalo,
+  MenuButtonIconContainer,
+} from './BaseMenu'
 
 export const MenuItem = styled.div<{
   readonly divider?: boolean
@@ -50,12 +59,17 @@ export interface MenuItemProps
 
 interface MenuProps extends Omit<BaseMenuProps, 'components'> {
   /**
+   * The icon element for menu button.
+   *
+   * Default: `MoreVertIcon`
+   */
+  readonly icon?: IconType
+  /**
    * An array of items in the drop down menu.
    */
   readonly items: ReadonlyArray<MenuItemProps>
   /**
    * Override theme's default setting for `compact` if set.
-
    */
   readonly compact?: boolean
 }
@@ -66,9 +80,21 @@ interface MenuProps extends Omit<BaseMenuProps, 'components'> {
  * Forwards props to BaseMenu
  */
 export const Menu = memo<MenuProps>(
-  ({ items, compact: compactFromProps, ...props }) => {
+  ({
+    icon: buttonIcon = MoreVertIcon,
+    items,
+    compact: compactFromProps,
+    ...props
+  }) => {
     const { compact: compactFromTheme } = useTheme()
     const compact = compactFromProps ?? compactFromTheme
+
+    const button = (
+      <MenuButtonIconContainer>
+        <MenuButtonIcon icon={buttonIcon} />
+        <MenuButtonHalo />
+      </MenuButtonIconContainer>
+    )
 
     /**
      * Creates array of components using MenuItem to
@@ -97,7 +123,7 @@ export const Menu = memo<MenuProps>(
       [compact, items]
     )
 
-    return <BaseMenu components={components} {...props} />
+    return <BaseMenu button={button} components={components} {...props} />
   }
 )
 

--- a/packages/core/src/Menu/__snapshots__/index.test.tsx.snap
+++ b/packages/core/src/Menu/__snapshots__/index.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Menus Menu (default) 1`] = `
-.c4 {
+.c6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -21,13 +21,13 @@ exports[`Menus Menu (default) 1`] = `
   width: 24px;
 }
 
-.c4 > svg {
+.c6 > svg {
   fill: currentColor;
   height: 100%;
   width: auto;
 }
 
-.c9 {
+.c11 {
   position: fixed;
   top: 0;
   width: 360px;
@@ -45,7 +45,7 @@ exports[`Menus Menu (default) 1`] = `
   z-index: 0;
 }
 
-.c8 {
+.c10 {
   position: absolute;
   z-index: 1;
 }
@@ -60,13 +60,32 @@ exports[`Menus Menu (default) 1`] = `
 }
 
 .c5 {
+  position: relative;
+  height: 32px;
+  width: 32px;
+  border-radius: 50%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c7 {
   fill: inherit;
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
 }
 
-.c7 {
+.c9 {
   position: absolute;
   top: 0;
   right: 0;
@@ -84,18 +103,14 @@ exports[`Menus Menu (default) 1`] = `
 }
 
 .c3 {
-  position: relative;
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
-  height: 32px;
-  width: 32px;
-  border-radius: 50%;
   min-width: unset;
   padding: unset;
   outline: none;
-  border: 2px solid transparent;
   cursor: pointer;
+  border: 0;
   color: rgb(102,102,102);
   fill: rgb(102,102,102);
   background-color: transparent;
@@ -107,29 +122,33 @@ exports[`Menus Menu (default) 1`] = `
   border: 0;
 }
 
-.c3:hover {
-  border: 0 solid transparent;
-}
-
-.c3:hover .c6 {
-  background-color: rgba(204,204,204,0.16);
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-}
-
-.c3:focus:focus {
+.c3 .c4 {
   border: 2px solid transparent;
 }
 
-.c3:focus:focus .c6 {
+.c3:hover .c4 {
+  border: 0 solid transparent;
+}
+
+.c3:hover .c8 {
   background-color: rgba(204,204,204,0.16);
   -webkit-transform: scale(1);
   -ms-transform: scale(1);
   transform: scale(1);
 }
 
-.c3:active .c6 {
+.c3:focus:focus .c4 {
+  border: 2px solid transparent;
+}
+
+.c3:focus:focus .c8 {
+  background-color: rgba(204,204,204,0.16);
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.c3:active .c8 {
   background-color: rgba(204,204,204,0.24);
   -webkit-transform: scale(1.06);
   -ms-transform: scale(1.06);
@@ -159,36 +178,40 @@ exports[`Menus Menu (default) 1`] = `
           onPointerUp={[Function]}
           type="button"
         >
-          <span
-            className="c4 c5 "
-            role="img"
-            size="medium"
-          >
-            <svg
-              height="1em"
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
-              />
-            </svg>
-          </span>
           <div
-            className="c6 c7"
-          />
+            className="c4 c5"
+          >
+            <span
+              className="c6 c7 "
+              role="img"
+              size="medium"
+            >
+              <svg
+                height="1em"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+            <div
+              className="c8 c9"
+            />
+          </div>
         </button>
       </div>
     </div>
   </div>
   <div>
     <div
-      className="c8"
+      className="c10"
       id="layer-2"
     >
       <div
-        className="c9"
+        className="c11"
       />
     </div>
   </div>
@@ -196,7 +219,7 @@ exports[`Menus Menu (default) 1`] = `
 `;
 
 exports[`Menus Menu (disabled) 1`] = `
-.c4 {
+.c6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -216,13 +239,13 @@ exports[`Menus Menu (disabled) 1`] = `
   width: 24px;
 }
 
-.c4 > svg {
+.c6 > svg {
   fill: currentColor;
   height: 100%;
   width: auto;
 }
 
-.c9 {
+.c11 {
   position: fixed;
   top: 0;
   width: 360px;
@@ -240,7 +263,7 @@ exports[`Menus Menu (disabled) 1`] = `
   z-index: 0;
 }
 
-.c8 {
+.c10 {
   position: absolute;
   z-index: 1;
 }
@@ -255,13 +278,32 @@ exports[`Menus Menu (disabled) 1`] = `
 }
 
 .c5 {
+  position: relative;
+  height: 32px;
+  width: 32px;
+  border-radius: 50%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c7 {
   fill: inherit;
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
 }
 
-.c7 {
+.c9 {
   position: absolute;
   top: 0;
   right: 0;
@@ -279,18 +321,14 @@ exports[`Menus Menu (disabled) 1`] = `
 }
 
 .c3 {
-  position: relative;
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
-  height: 32px;
-  width: 32px;
-  border-radius: 50%;
   min-width: unset;
   padding: unset;
   outline: none;
-  border: 2px solid transparent;
   cursor: pointer;
+  border: 0;
   color: rgb(102,102,102);
   fill: rgb(102,102,102);
   background-color: transparent;
@@ -306,29 +344,33 @@ exports[`Menus Menu (disabled) 1`] = `
   border: 0;
 }
 
-.c3:hover {
-  border: 0 solid transparent;
-}
-
-.c3:hover .c6 {
-  background-color: rgba(204,204,204,0.16);
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-}
-
-.c3:focus:focus {
+.c3 .c4 {
   border: 2px solid transparent;
 }
 
-.c3:focus:focus .c6 {
+.c3:hover .c4 {
+  border: 0 solid transparent;
+}
+
+.c3:hover .c8 {
   background-color: rgba(204,204,204,0.16);
   -webkit-transform: scale(1);
   -ms-transform: scale(1);
   transform: scale(1);
 }
 
-.c3:active .c6 {
+.c3:focus:focus .c4 {
+  border: 2px solid transparent;
+}
+
+.c3:focus:focus .c8 {
+  background-color: rgba(204,204,204,0.16);
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.c3:active .c8 {
   background-color: rgba(204,204,204,0.24);
   -webkit-transform: scale(1.06);
   -ms-transform: scale(1.06);
@@ -358,36 +400,40 @@ exports[`Menus Menu (disabled) 1`] = `
           onPointerUp={[Function]}
           type="button"
         >
-          <span
-            className="c4 c5 "
-            role="img"
-            size="medium"
-          >
-            <svg
-              height="1em"
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
-              />
-            </svg>
-          </span>
           <div
-            className="c6 c7"
-          />
+            className="c4 c5"
+          >
+            <span
+              className="c6 c7 "
+              role="img"
+              size="medium"
+            >
+              <svg
+                height="1em"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+            <div
+              className="c8 c9"
+            />
+          </div>
         </button>
       </div>
     </div>
   </div>
   <div>
     <div
-      className="c8"
+      className="c10"
       id="layer-8"
     >
       <div
-        className="c9"
+        className="c11"
       />
     </div>
   </div>
@@ -395,7 +441,7 @@ exports[`Menus Menu (disabled) 1`] = `
 `;
 
 exports[`Menus Menu (left) 1`] = `
-.c4 {
+.c6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -415,13 +461,13 @@ exports[`Menus Menu (left) 1`] = `
   width: 24px;
 }
 
-.c4 > svg {
+.c6 > svg {
   fill: currentColor;
   height: 100%;
   width: auto;
 }
 
-.c9 {
+.c11 {
   position: fixed;
   top: 0;
   width: 360px;
@@ -439,7 +485,7 @@ exports[`Menus Menu (left) 1`] = `
   z-index: 0;
 }
 
-.c8 {
+.c10 {
   position: absolute;
   z-index: 1;
 }
@@ -454,13 +500,32 @@ exports[`Menus Menu (left) 1`] = `
 }
 
 .c5 {
+  position: relative;
+  height: 32px;
+  width: 32px;
+  border-radius: 50%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c7 {
   fill: inherit;
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
 }
 
-.c7 {
+.c9 {
   position: absolute;
   top: 0;
   right: 0;
@@ -478,18 +543,14 @@ exports[`Menus Menu (left) 1`] = `
 }
 
 .c3 {
-  position: relative;
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
-  height: 32px;
-  width: 32px;
-  border-radius: 50%;
   min-width: unset;
   padding: unset;
   outline: none;
-  border: 2px solid transparent;
   cursor: pointer;
+  border: 0;
   color: rgb(102,102,102);
   fill: rgb(102,102,102);
   background-color: transparent;
@@ -501,29 +562,33 @@ exports[`Menus Menu (left) 1`] = `
   border: 0;
 }
 
-.c3:hover {
-  border: 0 solid transparent;
-}
-
-.c3:hover .c6 {
-  background-color: rgba(204,204,204,0.16);
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-}
-
-.c3:focus:focus {
+.c3 .c4 {
   border: 2px solid transparent;
 }
 
-.c3:focus:focus .c6 {
+.c3:hover .c4 {
+  border: 0 solid transparent;
+}
+
+.c3:hover .c8 {
   background-color: rgba(204,204,204,0.16);
   -webkit-transform: scale(1);
   -ms-transform: scale(1);
   transform: scale(1);
 }
 
-.c3:active .c6 {
+.c3:focus:focus .c4 {
+  border: 2px solid transparent;
+}
+
+.c3:focus:focus .c8 {
+  background-color: rgba(204,204,204,0.16);
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.c3:active .c8 {
   background-color: rgba(204,204,204,0.24);
   -webkit-transform: scale(1.06);
   -ms-transform: scale(1.06);
@@ -553,36 +618,40 @@ exports[`Menus Menu (left) 1`] = `
           onPointerUp={[Function]}
           type="button"
         >
-          <span
-            className="c4 c5 "
-            role="img"
-            size="medium"
-          >
-            <svg
-              height="1em"
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
-              />
-            </svg>
-          </span>
           <div
-            className="c6 c7"
-          />
+            className="c4 c5"
+          >
+            <span
+              className="c6 c7 "
+              role="img"
+              size="medium"
+            >
+              <svg
+                height="1em"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+            <div
+              className="c8 c9"
+            />
+          </div>
         </button>
       </div>
     </div>
   </div>
   <div>
     <div
-      className="c8"
+      className="c10"
       id="layer-4"
     >
       <div
-        className="c9"
+        className="c11"
       />
     </div>
   </div>
@@ -590,7 +659,7 @@ exports[`Menus Menu (left) 1`] = `
 `;
 
 exports[`Menus Menu (right) 1`] = `
-.c4 {
+.c6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -610,13 +679,13 @@ exports[`Menus Menu (right) 1`] = `
   width: 24px;
 }
 
-.c4 > svg {
+.c6 > svg {
   fill: currentColor;
   height: 100%;
   width: auto;
 }
 
-.c9 {
+.c11 {
   position: fixed;
   top: 0;
   width: 360px;
@@ -634,7 +703,7 @@ exports[`Menus Menu (right) 1`] = `
   z-index: 0;
 }
 
-.c8 {
+.c10 {
   position: absolute;
   z-index: 1;
 }
@@ -649,13 +718,32 @@ exports[`Menus Menu (right) 1`] = `
 }
 
 .c5 {
+  position: relative;
+  height: 32px;
+  width: 32px;
+  border-radius: 50%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c7 {
   fill: inherit;
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
 }
 
-.c7 {
+.c9 {
   position: absolute;
   top: 0;
   right: 0;
@@ -673,18 +761,14 @@ exports[`Menus Menu (right) 1`] = `
 }
 
 .c3 {
-  position: relative;
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
-  height: 32px;
-  width: 32px;
-  border-radius: 50%;
   min-width: unset;
   padding: unset;
   outline: none;
-  border: 2px solid transparent;
   cursor: pointer;
+  border: 0;
   color: rgb(102,102,102);
   fill: rgb(102,102,102);
   background-color: transparent;
@@ -696,29 +780,33 @@ exports[`Menus Menu (right) 1`] = `
   border: 0;
 }
 
-.c3:hover {
-  border: 0 solid transparent;
-}
-
-.c3:hover .c6 {
-  background-color: rgba(204,204,204,0.16);
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-}
-
-.c3:focus:focus {
+.c3 .c4 {
   border: 2px solid transparent;
 }
 
-.c3:focus:focus .c6 {
+.c3:hover .c4 {
+  border: 0 solid transparent;
+}
+
+.c3:hover .c8 {
   background-color: rgba(204,204,204,0.16);
   -webkit-transform: scale(1);
   -ms-transform: scale(1);
   transform: scale(1);
 }
 
-.c3:active .c6 {
+.c3:focus:focus .c4 {
+  border: 2px solid transparent;
+}
+
+.c3:focus:focus .c8 {
+  background-color: rgba(204,204,204,0.16);
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.c3:active .c8 {
   background-color: rgba(204,204,204,0.24);
   -webkit-transform: scale(1.06);
   -ms-transform: scale(1.06);
@@ -748,36 +836,40 @@ exports[`Menus Menu (right) 1`] = `
           onPointerUp={[Function]}
           type="button"
         >
-          <span
-            className="c4 c5 "
-            role="img"
-            size="medium"
-          >
-            <svg
-              height="1em"
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
-              />
-            </svg>
-          </span>
           <div
-            className="c6 c7"
-          />
+            className="c4 c5"
+          >
+            <span
+              className="c6 c7 "
+              role="img"
+              size="medium"
+            >
+              <svg
+                height="1em"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+            <div
+              className="c8 c9"
+            />
+          </div>
         </button>
       </div>
     </div>
   </div>
   <div>
     <div
-      className="c8"
+      className="c10"
       id="layer-6"
     >
       <div
-        className="c9"
+        className="c11"
       />
     </div>
   </div>


### PR DESCRIPTION
BREAKING CHANGE:
- Refactors `BaseMenu` to use `ReactNode instead of `icon` prop
to allow customization of the menu button.
- Adds `MenuButtonIconContainer` and exports `MenuButtonIcon` and
`MenuButtonHalo` in order to create icon button component as before.