### PR TITLE
fix(docs): use relative licenses.txt path

### DIFF
--- a/packages/docs/src/Licenses.tsx
+++ b/packages/docs/src/Licenses.tsx
@@ -22,7 +22,7 @@ export const Licenses: React.FC<ModalProps> = ({ onClose, ...props }) => {
 
   useEffect(() => {
     const fix = async () => {
-      const response = await fetch('/licenses.txt')
+      const response = await fetch('licenses.txt')
       const data = await response.text()
       setLicense(data)
     }


### PR DESCRIPTION
The GitHub pages for practical-react-components is served from a folder,
so the path to the licenses.txt file needs to be relative.