### PR TITLE
fix(select): call onBlur prop on blur

### DIFF
--- a/packages/core/src/Select/BaseSelect.tsx
+++ b/packages/core/src/Select/BaseSelect.tsx
@@ -574,21 +574,17 @@ export function BaseSelect<V extends string = string>({
     }
   }, [isOpen, listRef, itemRefs, valueIndex])
 
-  const handleFocusOut: React.EventHandler<React.FocusEvent> = useCallback(
-    e => {
-      if (popupAnchorEl?.contains(e.target) ?? false) {
-        setKeyboardOn()
-        closePopover()
-      }
-    },
-    [closePopover, popupAnchorEl, setKeyboardOn]
-  )
+  const handleBlur: React.EventHandler<React.FocusEvent> = useCallback(() => {
+    onBlur?.(true)
+    setKeyboardOn()
+    closePopover()
+  }, [closePopover, onBlur, setKeyboardOn])
 
   return (
     <SelectContainer
       width={width}
       ref={setPopupAnchorEl}
-      onBlur={handleFocusOut}
+      onBlur={handleBlur}
       {...props}
     >
       <BaseSelectSelector


### PR DESCRIPTION
When refactoring the Select the call to the onBlur prop was accidentally removed. This restores that call which makes onBlur work as expected again for the select component.