### PR TITLE
fix(menu): omit `button` prop from Menu

### DIFF
--- a/packages/core/src/Menu/Menu.tsx
+++ b/packages/core/src/Menu/Menu.tsx
@@ -57,7 +57,7 @@ export interface MenuItemProps
   readonly compact?: boolean
 }
 
-interface MenuProps extends Omit<BaseMenuProps, 'components'> {
+interface MenuProps extends Omit<BaseMenuProps, 'components' | 'button'> {
   /**
    * The icon element for menu button.
    *


### PR DESCRIPTION
Forgot to omit `button` prop from Menu when I refactored `BaseMenu`. Menu shouldn't have `button` prop. 