### PR TITLE
feat(toast): support two lines label in Toast

### DIFF
--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -22,19 +22,12 @@ import { Header } from './components/Header'
 import { Footer } from './components/Footer'
 import { MainSection } from './components/Content'
 import { BaseDialog, DialogWidth } from './BaseDialog'
+import { twoLinesClamp } from '../utils/twoLinesClamp'
 
 export const HeaderTitle = styled(Typography).attrs({
   variant: 'dialog-heading',
 })`
-  /* stylelint-disable-next-line value-no-vendor-prefix */
-  display: -webkit-box;
-  /* stylelint-disable-next-line property-no-vendor-prefix */
-  -webkit-line-clamp: 2;
-  /* stylelint-disable-next-line property-no-vendor-prefix */
-  -webkit-box-orient: vertical;
-  /* stylelint-disable-next-line property-no-vendor-prefix */
-  -moz-box-orient: vertical;
-  overflow: hidden;
+  ${twoLinesClamp}
 `
 
 export interface DialogProps extends ModalProps {

--- a/packages/core/src/Toast/toastCreators.tsx
+++ b/packages/core/src/Toast/toastCreators.tsx
@@ -21,6 +21,7 @@ import {
   BaseToastValue,
 } from './context'
 import { Theme } from '../theme'
+import { twoLinesClamp } from '../utils/twoLinesClamp'
 
 const getIconColor = (theme: Theme, iconType?: ToastIconType) => {
   const { color } = theme
@@ -48,6 +49,7 @@ export const ToastLabel = styled(Typography).attrs({
   readonly hasEmphasis: boolean
 }>`
   height: 100%;
+  ${twoLinesClamp}
 
   ${({ hasCloseButton }) =>
     !hasCloseButton

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './withField'
+export * from './twoLinesClamp'

--- a/packages/core/src/utils/twoLinesClamp.ts
+++ b/packages/core/src/utils/twoLinesClamp.ts
@@ -1,0 +1,24 @@
+import { css } from 'styled-components'
+
+/**
+ * A styled-components mixin that truncates two-lines text with ellipsis.
+ *
+ * An example:
+ * ```tsx
+ * const Div = styled.div`
+ *   ${twoLinesClamp};
+ * `
+ * ```
+ */
+export const twoLinesClamp = css`
+  /* stylelint-disable-next-line value-no-vendor-prefix */
+  display: -webkit-box;
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-line-clamp: 2;
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-box-orient: vertical;
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -moz-box-orient: vertical;
+  overflow: hidden;
+  white-space: pre-wrap;
+`


### PR DESCRIPTION
Closes #16

![two-row-label](https://user-images.githubusercontent.com/24866179/109138220-6c241c80-775a-11eb-8abb-d77a4e973aa6.png)
