### PR TITLE
fix(simpletable): limit transition property

### DIFF
--- a/packages/core/src/SimpleTable/__snapshots__/index.test.tsx.snap
+++ b/packages/core/src/SimpleTable/__snapshots__/index.test.tsx.snap
@@ -78,8 +78,8 @@ exports[`SimpleTable SimpleTable 1`] = `
   width: 100%;
   height: 56px;
   text-align: left;
-  -webkit-transition: all 200ms;
-  transition: all 200ms;
+  -webkit-transition: box-shadow 200ms;
+  transition: box-shadow 200ms;
   cursor: pointer;
 }
 
@@ -105,8 +105,8 @@ exports[`SimpleTable SimpleTable 1`] = `
   width: 100%;
   height: 56px;
   text-align: left;
-  -webkit-transition: all 200ms;
-  transition: all 200ms;
+  -webkit-transition: box-shadow 200ms;
+  transition: box-shadow 200ms;
   opacity: 0.48;
   pointer-events: none;
   cursor: unset;

--- a/packages/core/src/SimpleTable/index.tsx
+++ b/packages/core/src/SimpleTable/index.tsx
@@ -96,9 +96,6 @@ const SimpleTableHeader: React.FC<SimpleTableHeaderProps> = ({
  * SimpleTableRow
  *
  * A single row in the table used to group cells.
- * Note that there is no div associated with this,
- * it is just a convenience component to pass proper
- * keys to the grid cells.
  */
 
 const TableRow = styled.tr<{
@@ -115,7 +112,7 @@ const TableRow = styled.tr<{
 
   text-align: left;
 
-  transition: all 200ms;
+  transition: box-shadow 200ms;
 
   &:nth-child(odd) {
     background-color: ${({ theme }) => theme.color.background03()};
@@ -246,7 +243,6 @@ interface SimpleTableProps extends BaseProps {
   readonly maxHeight: number
   /**
    * Override theme's default setting for `compact` if set.
-
    */
   readonly compact?: boolean
   /**


### PR DESCRIPTION
Limit transition property in order to avoid to move some component on hover.