### PR TITLE
fix(docs): CardHeader in Basic usage in docs

### DIFF
--- a/packages/docs/src/mdx/coreComponents/Card.mdx
+++ b/packages/docs/src/mdx/coreComponents/Card.mdx
@@ -424,7 +424,9 @@ export const onClick = () => {}
 
 ```typescript type=live
 <Card>
-  <CardHeader header="Normal height header" height="normal" />
+  <CardHeader>
+    <CardHeaderTypography>CardHeader</CardHeaderTypography>
+  </CardHeader>
   <CardContent>
     <Typography>CardContent</Typography>
   </CardContent>


### PR DESCRIPTION
Found wrong example in docs and fixed it.

|Before |After |
|--|--|
| ![before-card](https://user-images.githubusercontent.com/24866179/113154838-b6f0f280-9238-11eb-9f18-9cb5d192973b.png)|![after-card](https://user-images.githubusercontent.com/24866179/113154858-bb1d1000-9238-11eb-98df-945e68b9dc5f.png)|