### PR TITLE
fix(menu): prevent event from bubbling up to the clickable wrapper

### DIFF
--- a/packages/core/src/Menu/BaseMenu.tsx
+++ b/packages/core/src/Menu/BaseMenu.tsx
@@ -397,6 +397,15 @@ export const BaseMenu = memo<BaseMenuProps>(
       hideMenu()
     }, [hideMenu])
 
+    const onClickHideAndBlurMenu = useCallback(
+      event => {
+        // Prevent event from bubbling up to the wrapper which is clickable
+        event.stopPropagation()
+        hideAndBlurMenu()
+      },
+      [hideAndBlurMenu]
+    )
+
     const handleBlur = useCallback<React.FocusEventHandler<BaseElement>>(
       e => {
         onBlur?.(e)
@@ -522,7 +531,7 @@ export const BaseMenu = memo<BaseMenuProps>(
             anchorEl={anchorRef.current}
             onScroll={hideAndBlurMenu}
           >
-            <MenuList onEscape={hideMenu} onClick={hideAndBlurMenu}>
+            <MenuList onEscape={hideMenu} onClick={onClickHideAndBlurMenu}>
               {components.map((component, index) => (
                 <BaseItem
                   key={index}

--- a/packages/ui-tests/src/coreComponents/Table.cypress.tsx
+++ b/packages/ui-tests/src/coreComponents/Table.cypress.tsx
@@ -146,7 +146,7 @@ const Test = () => {
                 />
               </>
             }
-            clickable={index === 5}
+            clickable={index === 1}
             onClicked={clickFunc}
           >
             <Typography>{device.serialNumber}</Typography>

--- a/packages/ui-tests/src/coreComponents/Table.spec.ts
+++ b/packages/ui-tests/src/coreComponents/Table.spec.ts
@@ -39,9 +39,26 @@ context('Table', () => {
     // And also `cy.hover` has opened issue (https://github.com/cypress-io/cypress/issues/10)
   })
 
+  it('Menu on row should open menu item and only menu item should be clicked, should not click the row', () => {
+    cy.get('[data-cy=tableRow]')
+      .eq(1)
+      .within(() => {
+        // show menu
+        cy.get('[class*="TableCells__TableCell"]').eq(3).invoke('show')
+        cy.get('[data-cy=tableRowMenu]').as('clickableRowMenu')
+        cy.get('@clickableRowMenu').click()
+      })
+      .then(() => {
+        cy.contains('Item 1').click()
+        // close menu
+        cy.get('@clickableRowMenu').click()
+      })
+    cy.get('main').contains('Row is clicked').should('not.exist')
+  })
+
   it('clickable row should not have checkbox and is clickable', () => {
-    cy.get('[data-cy=tableRow]').eq(5).find(checkboxEl).should('not.exist')
-    cy.get('[data-cy=tableRow]').eq(5).click()
+    cy.get('[data-cy=tableRow]').eq(1).find(checkboxEl).should('not.exist')
+    cy.get('[data-cy=tableRow]').eq(1).click()
     cy.get('main').contains('Row is clicked')
   })
 


### PR DESCRIPTION
Added stopPropagation() to onClick handler on menu list in order to
prevent event from bubbling up to the wrapper which is clickable.
Also added cypress test for this case.