### PR TITLE
feat(button): danger and success variant

### DIFF
--- a/packages/core/src/Button/index.tsx
+++ b/packages/core/src/Button/index.tsx
@@ -78,6 +78,68 @@ export const NativeButton = styled.button<{
           background-color: ${theme.color.elementPrimary()};
         }
       `
+    } else if (variant === 'danger') {
+      return css`
+        color: ${theme.color.text00()};
+        fill: ${theme.color.text00()};
+        background-color: ${theme.color.elementError()};
+        box-shadow: ${theme.shadow.primaryButton};
+
+        &:hover {
+          background-color: ${theme.color.textError()};
+          box-shadow: ${theme.shadow.primaryButton};
+        }
+
+        &:focus {
+          ${visibleFocus
+            ? css`
+                background-color: ${theme.color.elementError()};
+                box-shadow: ${theme.shadow.primaryButton};
+                border: 2px solid ${theme.color.textError()};
+              `
+            : undefined};
+        }
+
+        &:active {
+          background-color: ${theme.color.textError()};
+          box-shadow: 0 0 0 4px ${theme.color.elementError(opacity[24])};
+        }
+
+        &:disabled {
+          background-color: ${theme.color.elementError()};
+        }
+      `
+    } else if (variant === 'success') {
+      return css`
+        color: ${theme.color.text00()};
+        fill: ${theme.color.text00()};
+        background-color: ${theme.color.elementSuccess()};
+        box-shadow: ${theme.shadow.primaryButton};
+
+        &:hover {
+          background-color: ${theme.color.textSuccess()};
+          box-shadow: ${theme.shadow.primaryButton};
+        }
+
+        &:focus {
+          ${visibleFocus
+            ? css`
+                background-color: ${theme.color.elementSuccess()};
+                box-shadow: ${theme.shadow.primaryButton};
+                border: 2px solid ${theme.color.textSuccess()};
+              `
+            : undefined};
+        }
+
+        &:active {
+          background-color: ${theme.color.textSuccess()};
+          box-shadow: 0 0 0 4px ${theme.color.elementSuccess(opacity[24])};
+        }
+
+        &:disabled {
+          background-color: ${theme.color.elementSuccess()};
+        }
+      `
     } else if (accent) {
       return css`
         color: ${theme.color.elementPrimary()};
@@ -204,7 +266,7 @@ const LabelContainer = styled.span.attrs({ className: 'sc-LabelContainer' })<{
 type BaseElement = HTMLButtonElement
 type BaseProps = React.ButtonHTMLAttributes<BaseElement>
 type ButtonType = 'button' | 'submit' | 'reset'
-export type ButtonVariantType = 'primary' | 'secondary'
+export type ButtonVariantType = 'primary' | 'secondary' | 'danger' | 'success'
 export type ButtonClickHandler = React.MouseEventHandler<BaseElement>
 
 interface BaseButtonProps extends BaseProps {
@@ -337,7 +399,11 @@ const IconNativeButton = styled(NativeButton)<{
   padding: unset;
 
   ${({ variant, accent, visibleFocus, theme }) => {
-    if (variant === 'primary') {
+    if (
+      variant === 'primary' ||
+      variant === 'danger' ||
+      variant === 'success'
+    ) {
       return undefined
     } else if (accent) {
       return css`
@@ -502,46 +568,127 @@ export const IconButton = React.forwardRef<BaseElement, IconButtonProps>(
 
 export const NativeIconTextButton = styled.button<{
   readonly visibleFocus: boolean
+  readonly variant: Omit<ButtonVariantType, 'secondary'>
 }>`
   ${COMMON_STYLE}
   border: none;
   padding: 0 ${spacing.large} 0 0;
-  ${({ visibleFocus, theme }) => {
-    return css`
-      color: ${theme.color.text04()};
-      fill: ${theme.color.text04()};
-      background-color: transparent;
+  ${({ visibleFocus, variant, theme }) => {
+    if (variant === 'primary') {
+      return css`
+        color: ${theme.color.text04()};
+        fill: ${theme.color.text04()};
+        background-color: transparent;
 
-      &:hover {
-        color: ${theme.color.text03()};
-        background-color: ${theme.color.element11(opacity[16])};
-        ${IconContainer} {
-          background-color: ${theme.color.textPrimary()};
-        }
-      }
-      &:focus {
-        ${visibleFocus
-          ? css`
-              color: ${theme.color.text04()};
-              background-color: ${theme.color.element11(opacity[16])};
-            `
-          : undefined};
-      }
-      &:active {
-        box-shadow: 0 0 0 4px ${theme.color.elementPrimary(opacity[24])};
-        background-color: ${theme.color.element11(opacity[24])};
-      }
-      &:disabled {
-        opacity: ${opacity[48]};
-        cursor: default;
-        box-shadow: none;
         &:hover {
+          color: ${theme.color.text03()};
+          background-color: ${theme.color.element11(opacity[16])};
           ${IconContainer} {
-            background-color: ${theme.color.elementPrimary()};
+            background-color: ${theme.color.textPrimary()};
           }
         }
-      }
-    `
+        &:focus {
+          ${visibleFocus
+            ? css`
+                color: ${theme.color.text04()};
+                background-color: ${theme.color.element11(opacity[16])};
+              `
+            : undefined};
+        }
+        &:active {
+          box-shadow: 0 0 0 4px ${theme.color.elementPrimary(opacity[24])};
+          background-color: ${theme.color.element11(opacity[24])};
+        }
+        &:disabled {
+          opacity: ${opacity[48]};
+          cursor: default;
+          box-shadow: none;
+          &:hover {
+            ${IconContainer} {
+              background-color: ${theme.color.elementPrimary()};
+            }
+          }
+        }
+      `
+    } else if (variant === 'danger') {
+      return css`
+        color: ${theme.color.text04()};
+        fill: ${theme.color.text04()};
+        background-color: transparent;
+        ${IconContainer} {
+          background-color: ${theme.color.elementError()};
+        }
+
+        &:hover {
+          color: ${theme.color.text03()};
+          background-color: ${theme.color.element11(opacity[16])};
+          ${IconContainer} {
+            background-color: ${theme.color.textError()};
+          }
+        }
+        &:focus {
+          ${visibleFocus
+            ? css`
+                color: ${theme.color.text04()};
+                background-color: ${theme.color.element11(opacity[16])};
+              `
+            : undefined};
+        }
+        &:active {
+          box-shadow: 0 0 0 4px ${theme.color.elementError(opacity[24])};
+          background-color: ${theme.color.element11(opacity[24])};
+        }
+        &:disabled {
+          opacity: ${opacity[48]};
+          cursor: default;
+          box-shadow: none;
+          &:hover {
+            ${IconContainer} {
+              background-color: ${theme.color.elementError()};
+            }
+          }
+        }
+      `
+    } else if (variant === 'success') {
+      return css`
+        color: ${theme.color.text04()};
+        fill: ${theme.color.text04()};
+        background-color: transparent;
+        ${IconContainer} {
+          background-color: ${theme.color.elementSuccess()};
+        }
+
+        &:hover {
+          color: ${theme.color.text03()};
+          background-color: ${theme.color.element11(opacity[16])};
+          ${IconContainer} {
+            background-color: ${theme.color.textSuccess()};
+          }
+        }
+        &:focus {
+          ${visibleFocus
+            ? css`
+                color: ${theme.color.text04()};
+                background-color: ${theme.color.element11(opacity[16])};
+              `
+            : undefined};
+        }
+        &:active {
+          box-shadow: 0 0 0 4px ${theme.color.elementSuccess(opacity[24])};
+          background-color: ${theme.color.element11(opacity[24])};
+        }
+        &:disabled {
+          opacity: ${opacity[48]};
+          cursor: default;
+          box-shadow: none;
+          &:hover {
+            ${IconContainer} {
+              background-color: ${theme.color.elementSuccess()};
+            }
+          }
+        }
+      `
+    }
   }}
 `
 const IconContainer = styled(Icon)`
@@ -568,6 +715,7 @@ export interface IconTextButtonProps
    * The icon element.
    */
   readonly icon: IconType
+  readonly variant?: Omit<ButtonVariantType, 'secondary'>
 }
 
 // eslint-disable-next-line react/display-name
@@ -584,6 +732,7 @@ export const IconTextButton = React.forwardRef<
       onPointerUp,
       onFocus,
       label,
+      variant = 'primary',
       ...props
     },
     ref
@@ -624,6 +773,7 @@ export const IconTextButton = React.forwardRef<
         onFocus={handleFocus}
         {...props}
         visibleFocus={visibleFocus}
+        variant={variant}
       >
         <Container>
           <IconContainer icon={icon} />

--- a/packages/core/src/Chip/__snapshots__/index.test.tsx.snap
+++ b/packages/core/src/Chip/__snapshots__/index.test.tsx.snap
@@ -250,9 +250,9 @@ exports[`Chips error 1`] = `
   border-radius: 2px;
   color: rgb(41,41,41);
   background-color: rgb(255,235,238);
-  color: rgb(211,47,47);
+  color: rgb(198,40,40);
   padding-left: 0;
-  border: 1px solid rgb(211,47,47);
+  border: 1px solid rgb(229,57,53);
 }
 
 .c4 {
@@ -260,7 +260,7 @@ exports[`Chips error 1`] = `
   -ms-flex: 0 0 min-content;
   flex: 0 0 min-content;
   overflow: visible;
-  color: rgb(211,47,47);
+  color: rgb(229,57,53);
 }
 
 .c5 {

--- a/packages/core/src/Input/__snapshots__/index.test.tsx.snap
+++ b/packages/core/src/Input/__snapshots__/index.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`TextInput NumberInput 1`] = `
 }
 
 .c2:focus-within .Input__ErrorLine-sc-5z5y11-2 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c2:focus-within .Input__ErrorLineContainer-sc-5z5y11-1 {
@@ -232,7 +232,7 @@ exports[`TextInput NumberInput 2`] = `
 }
 
 .c2:focus-within .Input__ErrorLine-sc-5z5y11-2 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c2:focus-within .Input__ErrorLineContainer-sc-5z5y11-1 {
@@ -400,7 +400,7 @@ exports[`TextInput NumberInput 3`] = `
 }
 
 .c2:focus-within .Input__ErrorLine-sc-5z5y11-2 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c2:focus-within .Input__ErrorLineContainer-sc-5z5y11-1 {
@@ -573,7 +573,7 @@ exports[`TextInput NumberInput 4`] = `
 }
 
 .c2:focus-within .Input__ErrorLine-sc-5z5y11-2 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c2:focus-within .Input__ErrorLineContainer-sc-5z5y11-1 {
@@ -749,7 +749,7 @@ exports[`TextInput NumberInput 5`] = `
 }
 
 .c2:focus-within .Input__ErrorLine-sc-5z5y11-2 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c2:focus-within .Input__ErrorLineContainer-sc-5z5y11-1 {
@@ -929,7 +929,7 @@ exports[`TextInput NumberInput 6`] = `
 }
 
 .c2:focus-within .Input__ErrorLine-sc-5z5y11-2 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c2:focus-within .Input__ErrorLineContainer-sc-5z5y11-1 {
@@ -1113,7 +1113,7 @@ exports[`TextInput NumberInput 7`] = `
 }
 
 .c2:focus-within .Input__ErrorLine-sc-5z5y11-2 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c2:focus-within .Input__ErrorLineContainer-sc-5z5y11-1 {
@@ -1281,7 +1281,7 @@ exports[`TextInput NumberInput 8`] = `
 }
 
 .c2:focus-within .Input__ErrorLine-sc-5z5y11-2 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c2:focus-within .Input__ErrorLineContainer-sc-5z5y11-1 {
@@ -1487,7 +1487,7 @@ exports[`TextInput NumberInput 9`] = `
 }
 
 .c2:focus-within .Input__ErrorLine-sc-5z5y11-2 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c2:focus-within .Input__ErrorLineContainer-sc-5z5y11-1 {
@@ -1628,7 +1628,7 @@ exports[`TextInput NumberInput 10`] = `
 }
 
 .c4 {
-  color: rgb(211,47,47);
+  color: rgb(229,57,53);
   line-height: 16px;
   background-color: transparent;
   display: -webkit-box;
@@ -1649,7 +1649,7 @@ exports[`TextInput NumberInput 10`] = `
 .c6 {
   position: relative;
   box-sizing: border-box;
-  border-bottom: 1px solid rgb(211,47,47);
+  border-bottom: 1px solid rgb(229,57,53);
   height: 100%;
   min-width: 8px;
   -webkit-box-flex: 1;
@@ -1677,7 +1677,7 @@ exports[`TextInput NumberInput 10`] = `
 }
 
 .c13:focus-within .c7 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c13:focus-within .c5 {
@@ -1685,7 +1685,7 @@ exports[`TextInput NumberInput 10`] = `
 }
 
 .c14:focus-within .c7 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c14:focus-within .c5 {
@@ -1693,7 +1693,7 @@ exports[`TextInput NumberInput 10`] = `
 }
 
 .c15:focus-within .c7 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c15:focus-within .c5 {
@@ -1701,7 +1701,7 @@ exports[`TextInput NumberInput 10`] = `
 }
 
 .c16:focus-within .c7 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c16:focus-within .c5 {
@@ -1709,7 +1709,7 @@ exports[`TextInput NumberInput 10`] = `
 }
 
 .c17:focus-within .c7 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c17:focus-within .c5 {
@@ -1717,7 +1717,7 @@ exports[`TextInput NumberInput 10`] = `
 }
 
 .c18:focus-within .c7 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c18:focus-within .c5 {
@@ -1757,7 +1757,7 @@ exports[`TextInput NumberInput 10`] = `
 }
 
 .c2:focus-within .c7 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c2:focus-within .c5 {
@@ -1952,7 +1952,7 @@ exports[`TextInput TextInput 1`] = `
 }
 
 .c2:focus-within .Input__ErrorLine-sc-5z5y11-2 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c2:focus-within .Input__ErrorLineContainer-sc-5z5y11-1 {
@@ -2114,7 +2114,7 @@ exports[`TextInput TextInput 2`] = `
 }
 
 .c2:focus-within .Input__ErrorLine-sc-5z5y11-2 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c2:focus-within .Input__ErrorLineContainer-sc-5z5y11-1 {
@@ -2280,7 +2280,7 @@ exports[`TextInput TextInput 3`] = `
 }
 
 .c2:focus-within .Input__ErrorLine-sc-5z5y11-2 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c2:focus-within .Input__ErrorLineContainer-sc-5z5y11-1 {
@@ -2450,7 +2450,7 @@ exports[`TextInput TextInput 4`] = `
 }
 
 .c2:focus-within .Input__ErrorLine-sc-5z5y11-2 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c2:focus-within .Input__ErrorLineContainer-sc-5z5y11-1 {
@@ -2624,7 +2624,7 @@ exports[`TextInput TextInput 5`] = `
 }
 
 .c2:focus-within .Input__ErrorLine-sc-5z5y11-2 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c2:focus-within .Input__ErrorLineContainer-sc-5z5y11-1 {
@@ -2802,7 +2802,7 @@ exports[`TextInput TextInput 6`] = `
 }
 
 .c2:focus-within .Input__ErrorLine-sc-5z5y11-2 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c2:focus-within .Input__ErrorLineContainer-sc-5z5y11-1 {
@@ -2964,7 +2964,7 @@ exports[`TextInput TextInput 7`] = `
 }
 
 .c2:focus-within .Input__ErrorLine-sc-5z5y11-2 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c2:focus-within .Input__ErrorLineContainer-sc-5z5y11-1 {
@@ -3164,7 +3164,7 @@ exports[`TextInput TextInput 8`] = `
 }
 
 .c2:focus-within .Input__ErrorLine-sc-5z5y11-2 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c2:focus-within .Input__ErrorLineContainer-sc-5z5y11-1 {
@@ -3299,7 +3299,7 @@ exports[`TextInput TextInput 9`] = `
 }
 
 .c4 {
-  color: rgb(211,47,47);
+  color: rgb(229,57,53);
   line-height: 16px;
   background-color: transparent;
   display: -webkit-box;
@@ -3320,7 +3320,7 @@ exports[`TextInput TextInput 9`] = `
 .c6 {
   position: relative;
   box-sizing: border-box;
-  border-bottom: 1px solid rgb(211,47,47);
+  border-bottom: 1px solid rgb(229,57,53);
   height: 100%;
   min-width: 8px;
   -webkit-box-flex: 1;
@@ -3348,7 +3348,7 @@ exports[`TextInput TextInput 9`] = `
 }
 
 .c13:focus-within .c7 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c13:focus-within .c5 {
@@ -3356,7 +3356,7 @@ exports[`TextInput TextInput 9`] = `
 }
 
 .c14:focus-within .c7 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c14:focus-within .c5 {
@@ -3364,7 +3364,7 @@ exports[`TextInput TextInput 9`] = `
 }
 
 .c15:focus-within .c7 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c15:focus-within .c5 {
@@ -3372,7 +3372,7 @@ exports[`TextInput TextInput 9`] = `
 }
 
 .c16:focus-within .c7 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c16:focus-within .c5 {
@@ -3380,7 +3380,7 @@ exports[`TextInput TextInput 9`] = `
 }
 
 .c17:focus-within .c7 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c17:focus-within .c5 {
@@ -3388,7 +3388,7 @@ exports[`TextInput TextInput 9`] = `
 }
 
 .c18:focus-within .c7 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c18:focus-within .c5 {
@@ -3428,7 +3428,7 @@ exports[`TextInput TextInput 9`] = `
 }
 
 .c2:focus-within .c7 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c2:focus-within .c5 {
@@ -3617,7 +3617,7 @@ exports[`TextInput TextInputCredentials 1`] = `
 }
 
 .c2:focus-within .Input__ErrorLine-sc-5z5y11-2 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c2:focus-within .Input__ErrorLineContainer-sc-5z5y11-1 {
@@ -3800,7 +3800,7 @@ exports[`TextInput TextInputCredentials 2`] = `
 }
 
 .c3:focus-within .Input__ErrorLine-sc-5z5y11-2 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c3:focus-within .Input__ErrorLineContainer-sc-5z5y11-1 {
@@ -4028,7 +4028,7 @@ exports[`TextInput TextInputCredentials 3`] = `
 }
 
 .c3:focus-within .Input__ErrorLine-sc-5z5y11-2 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c3:focus-within .Input__ErrorLineContainer-sc-5z5y11-1 {
@@ -4277,7 +4277,7 @@ exports[`TextInput TimeInput 1`] = `
 }
 
 .c16 {
-  color: rgb(211,47,47);
+  color: rgb(229,57,53);
   line-height: 16px;
   background-color: transparent;
   display: -webkit-box;
@@ -4298,7 +4298,7 @@ exports[`TextInput TimeInput 1`] = `
 .c18 {
   position: relative;
   box-sizing: border-box;
-  border-bottom: 1px solid rgb(211,47,47);
+  border-bottom: 1px solid rgb(229,57,53);
   height: 100%;
   min-width: 8px;
   -webkit-box-flex: 1;
@@ -4365,7 +4365,7 @@ exports[`TextInput TimeInput 1`] = `
 }
 
 .c3:focus-within .c19 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c3:focus-within .c17 {
@@ -4405,7 +4405,7 @@ exports[`TextInput TimeInput 1`] = `
 }
 
 .c8:focus-within .c19 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c8:focus-within .c17 {
@@ -4445,7 +4445,7 @@ exports[`TextInput TimeInput 1`] = `
 }
 
 .c15:focus-within .c19 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c15:focus-within .c17 {
@@ -4493,7 +4493,7 @@ exports[`TextInput TimeInput 1`] = `
 }
 
 .c23:focus-within .c19 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c23:focus-within .c17 {

--- a/packages/core/src/RadioButton/__snapshots__/index.test.tsx.snap
+++ b/packages/core/src/RadioButton/__snapshots__/index.test.tsx.snap
@@ -1657,7 +1657,7 @@ exports[`RadioButtons RadioButtonGroup 2`] = `
   position: absolute;
   top: 0;
   fill: transparent;
-  stroke: rgb(211,47,47);
+  stroke: rgb(229,57,53);
 }
 
 .c9 {

--- a/packages/core/src/Select/__snapshots__/MultiSelect.test.tsx.snap
+++ b/packages/core/src/Select/__snapshots__/MultiSelect.test.tsx.snap
@@ -937,7 +937,7 @@ exports[`Select Other 1`] = `
 .c3:hover,
 .c3:focus {
   background-color: rgb(255,235,238);
-  border-color: rgb(211,47,47);
+  border-color: rgb(229,57,53);
 }
 
 .c10 {

--- a/packages/core/src/Select/__snapshots__/SearchSelect.test.tsx.snap
+++ b/packages/core/src/Select/__snapshots__/SearchSelect.test.tsx.snap
@@ -556,7 +556,7 @@ exports[`Select Other 1`] = `
 .c3:hover,
 .c3:focus {
   background-color: rgb(255,235,238);
-  border-color: rgb(211,47,47);
+  border-color: rgb(229,57,53);
 }
 
 .c9 {

--- a/packages/core/src/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/core/src/Select/__snapshots__/Select.test.tsx.snap
@@ -926,7 +926,7 @@ exports[`Select Other 1`] = `
 .c3:hover,
 .c3:focus {
   background-color: rgb(255,235,238);
-  border-color: rgb(211,47,47);
+  border-color: rgb(229,57,53);
 }
 
 .c9 {

--- a/packages/core/src/StrengthIndicator/__snapshots__/index.test.tsx.snap
+++ b/packages/core/src/StrengthIndicator/__snapshots__/index.test.tsx.snap
@@ -148,7 +148,7 @@ exports[`StrengthIndicator Levels 2`] = `
 }
 
 .c4 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
   height: 100%;
   width: 100%;
   -webkit-transition: -webkit-transform 0.3s ease-in-out;
@@ -276,7 +276,7 @@ exports[`StrengthIndicator Levels 3`] = `
 }
 
 .c4 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
   height: 100%;
   width: 100%;
   -webkit-transition: -webkit-transform 0.3s ease-in-out;
@@ -532,7 +532,7 @@ exports[`StrengthIndicator Levels 5`] = `
 }
 
 .c4 {
-  background-color: rgb(56,142,60);
+  background-color: rgb(67,160,71);
   height: 100%;
   width: 100%;
   -webkit-transition: -webkit-transform 0.3s ease-in-out;

--- a/packages/core/src/TextArea/__snapshots__/index.test.tsx.snap
+++ b/packages/core/src/TextArea/__snapshots__/index.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`TextAreas TextArea 1`] = `
 }
 
 .c2:focus-within .TextArea__ErrorLine-sc-5zgztr-2 {
-  background-color: rgb(211,47,47);
+  background-color: rgb(229,57,53);
 }
 
 .c2:focus-within .TextArea__ErrorLineContainter-sc-5zgztr-1 {

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -64,6 +64,7 @@ export interface Color {
   readonly textLinkHover: CSSColor
   readonly textPrimary: CSSColor
   readonly textError: CSSColor
+  readonly textSuccess: CSSColor
   readonly background: CSSColor
   readonly background00: CSSColor
   readonly background01: CSSColor
@@ -180,7 +181,8 @@ const generateDefaultColors = (
     textLink: palette[`${color}600` as ColorName],
     textLinkHover: palette[`${color}700` as ColorName],
     textPrimary: palette[`${color}800` as ColorName],
-    textError: palette.red700,
+    textError: palette.red800,
+    textSuccess: palette.green800,
     background: palette.white,
     background00: palette.white,
     background01: palette.grey94,
@@ -200,8 +202,8 @@ const generateDefaultColors = (
     element16: palette.grey98,
     elementPrimary: palette[`${color}500` as ColorName],
     elementHalfPrimary: palette[`${color}600` as ColorName],
-    elementError: palette.red700,
-    elementSuccess: palette.green700,
+    elementError: palette.red600,
+    elementSuccess: palette.green600,
     elementWarning: palette.amber500,
     elementAccent: palette[`${color}500` as ColorName],
     elementBorder: palette.transparent,

--- a/packages/docs/src/mdx/coreComponents/Button.mdx
+++ b/packages/docs/src/mdx/coreComponents/Button.mdx
@@ -10,8 +10,9 @@ import {
   Button,
   IconTextButton,
   IconButton,
+  SpaceBlock,
 } from 'practical-react-components-core'
-import { AddIcon } from 'practical-react-components-icons'
+import { AddIcon, CloseIcon, CheckIcon } from 'practical-react-components-icons'
 
 # Button
 
@@ -30,14 +31,31 @@ export const Wrapper = styled.div`
 <Wrapper>
   <Button label="Primary" />
   <Button label="Primary" icon={AddIcon} />
+  <IconButton icon={AddIcon} />
+  <IconTextButton icon={AddIcon} label="Primary" />
+</Wrapper>
+<SpaceBlock variant={16} />
+<Wrapper>
   <Button label="Secondary" variant="secondary" />
   <Button label="Secondary" variant="secondary" icon={AddIcon} />
   <Button label="Secondary" variant="secondary" accent={true} />
   <Button label="Secondary" variant="secondary" icon={AddIcon} accent={true} />
-  <IconTextButton icon={AddIcon} label="Secondary" />
-  <IconButton icon={AddIcon} />
   <IconButton icon={AddIcon} variant="secondary" />
   <IconButton icon={AddIcon} variant="secondary" accent={true} />
+</Wrapper>
+<SpaceBlock variant={16} />
+<Wrapper>
+  <Button label="Danger" variant="danger" />
+  <Button label="Danger" variant="danger" icon={CloseIcon} />
+  <IconButton icon={CloseIcon} variant="danger" />
+  <IconTextButton label="Danger" icon={CloseIcon} variant="danger" />
+</Wrapper>
+<SpaceBlock variant={16} />
+<Wrapper>
+  <Button label="Success" variant="success" />
+  <Button label="Success" variant="success" icon={CheckIcon} />
+  <IconButton icon={CheckIcon} variant="success" />
+  <IconTextButton label="Success" icon={CheckIcon} variant="success" />
 </Wrapper>
 
 ## Basic usage
@@ -56,6 +74,22 @@ A button without background color by default.
 
 ```typescript type=live
 <Button label="Secondary" variant="secondary" />
+```
+
+### Danger button
+
+A button with an error style to represent dangerous actions. Eg: Delete user.
+
+```typescript type=live
+<Button label="Danger" variant="danger" />
+```
+
+### Success button
+
+A button with a success style to reperesent a positive action.
+
+```typescript type=live
+<Button label="Success" variant="success" />
 ```
 
 ### Clickable icon: Primary


### PR DESCRIPTION
Adds a "danger" variant which signifies a dangerous  action, such as deleting a user.
    
Adds a "success" variant which signifies a positive action.
    
The change affects

- Button
- IconButton
- IconTextButton
    
This change also affects a number of snapshots. This because a primary button uses `textPrimary` and `elementPrimary` to change the color between for instance the normal and hover state. `textError` and `elementError` however had the exact same color.
   
Had to add `textSuccess` since this color didn't exist at all, which seems like an error due to the fact that all other `element...` has an equivalent `text...`.

![prc_success_danger_button](https://user-images.githubusercontent.com/7765599/121743121-1acd4c80-cb01-11eb-8277-fac2af5302fc.png)