### PR TITLE
feat(docs): ThemeCreator

### DIFF
--- a/packages/docs/src/index.tsx
+++ b/packages/docs/src/index.tsx
@@ -18,6 +18,7 @@ import { Home } from './Home'
 import { Content } from './Content'
 
 import { Components } from './types'
+import { ThemeCreator } from './mdx/themeCreator/ThemeCreator'
 
 const practicalCoreModuleContext = require.context('./', true, /\.mdx$/)
 
@@ -108,6 +109,9 @@ ReactDOM.render(
                 <Switch>
                   <Route exact path="/">
                     <Home />
+                  </Route>
+                  <Route exact path="/theme-creator">
+                    <ThemeCreator />
                   </Route>
                   {componentDb.map(({ route, component: Component }) => (
                     <Route key={route} path={route}>

--- a/packages/docs/src/mdx/coreComponents/colorSelector.mdx
+++ b/packages/docs/src/mdx/coreComponents/colorSelector.mdx
@@ -1,0 +1,5 @@
+export const meta = {
+  name: 'Theme Creator',
+  route: '/theme-creator',
+  menu: 'Styles',
+}

--- a/packages/docs/src/mdx/themeCreator/ColorPicker.tsx
+++ b/packages/docs/src/mdx/themeCreator/ColorPicker.tsx
@@ -1,0 +1,172 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react'
+import styled from 'styled-components'
+import {
+  palette,
+  Tooltip,
+  shape,
+  ColorName,
+  CSSColor,
+  spacing,
+  componentSize,
+  PopOver,
+} from 'practical-react-components-core'
+import { useClickOutside } from 'react-hooks-shareable'
+
+const PALETTE_CONTAINER_HEIGHT = 300
+
+interface ColorBoxProps {
+  readonly color?: string
+  readonly selected: boolean
+}
+const ColorBox = styled.div<ColorBoxProps>`
+  background-color: ${({ color }) => color};
+  cursor: pointer;
+  height: ${componentSize.small};
+  width: ${componentSize.small};
+  ${({ selected }) =>
+    selected
+      ? `height: ${componentSize.mini};
+  width: ${componentSize.mini};
+  margin:2px`
+      : '0px'};
+`
+const SelectedColorBox = styled.div<ColorBoxProps>`
+  ${({ selected }) => (selected ? `border:2px solid;` : 'none')};
+`
+
+const ColorSegment = styled.div`
+  background-color: ${({ color }) => color};
+  cursor: pointer;
+  height: 20px;
+  border-radius: ${shape.radius.medium};
+  margin: 0 ${spacing.medium};
+`
+interface PaletteContainerProps {
+  readonly changeWidth?: number
+}
+
+const PaletteContainer = styled.div<PaletteContainerProps>`
+  overflow-y: scroll;
+  background-color: ${({ theme }) => theme.color.background()};
+  border: ${({ theme }) => theme.color.element13()} 2px solid;
+  border-radius: ${shape.radius.medium};
+  height: ${PALETTE_CONTAINER_HEIGHT}px;
+  display: flex;
+  flex-wrap: wrap;
+  width: ${({ changeWidth }) => changeWidth}px;
+  min-width: 115px;
+`
+interface PaletteColorProps {
+  readonly colorName: ColorName
+  readonly colorValue: CSSColor
+  readonly onChosenColor: (colorName: ColorName) => void
+  readonly selected: boolean
+}
+
+const PaletteColor: React.VFC<PaletteColorProps> = ({
+  colorName,
+  colorValue,
+  onChosenColor,
+  selected,
+}) => {
+  const onClick = useCallback(() => {
+    onChosenColor(colorName)
+  }, [colorName, onChosenColor])
+  return (
+    <div key={colorName}>
+      <Tooltip text={colorName}>
+        <SelectedColorBox selected={selected}>
+          <ColorBox
+            selected={selected}
+            color={colorValue()}
+            onClick={onClick}
+          />
+        </SelectedColorBox>
+      </Tooltip>
+    </div>
+  )
+}
+
+export interface ColorPickerProps {
+  readonly onChange: (value: ColorName) => void
+  readonly value: ColorName
+}
+
+export const ColorPicker: React.VFC<ColorPickerProps> = ({
+  onChange,
+  value,
+}) => {
+  const [directionUp, setDirectionUp] = useState(false)
+  const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null)
+  const [open, setOpen] = useState(false)
+  const checkWidth = useRef<HTMLDivElement | null>(null)
+  const currentWidth = checkWidth.current?.clientWidth
+  const colorSegment = useMemo(() => palette[value](), [value])
+
+  const checkDirection = useCallback(() => {
+    const { clientHeight } = document.documentElement
+    const elem = anchorEl?.getBoundingClientRect()
+    if (elem) {
+      const diff = Math.floor(clientHeight - elem.bottom)
+
+      // 300px is the height of <PaletteContainer>
+      if (diff < PALETTE_CONTAINER_HEIGHT) setDirectionUp(true)
+    }
+  }, [anchorEl])
+
+  const toggle = useCallback(() => {
+    setOpen(o => !o)
+    checkDirection()
+  }, [checkDirection])
+
+  const handler = useClickOutside(() => {
+    setOpen(false)
+  })
+
+  const removePopOver = useCallback(() => {
+    setOpen(o => !o)
+  }, [])
+
+  return (
+    <>
+      <div ref={setAnchorEl}>
+        <ColorSegment
+          color={colorSegment}
+          onClick={toggle}
+          onPointerDown={handler}
+          ref={checkWidth}
+        >
+          {open ? (
+            <PopOver
+              horizontalAlignment="center"
+              horizontalPosition="center"
+              verticalAlignment={directionUp ? 'bottom' : 'top'}
+              verticalPosition={directionUp ? 'top' : 'bottom'}
+              anchorEl={anchorEl}
+              onScroll={removePopOver}
+            >
+              <PaletteContainer changeWidth={currentWidth}>
+                {(
+                  Object.entries(palette) as ReadonlyArray<
+                    [ColorName, CSSColor]
+                  >
+                )
+                  // Filter out transparent "color"
+                  .filter(([colorName]) => colorName !== 'transparent')
+                  .map(([colorName, colorValue]) => (
+                    <PaletteColor
+                      key={colorName}
+                      selected={value === colorName}
+                      colorValue={colorValue}
+                      onChosenColor={onChange}
+                      colorName={colorName}
+                    />
+                  ))}
+              </PaletteContainer>
+            </PopOver>
+          ) : null}
+        </ColorSegment>
+      </div>
+    </>
+  )
+}

--- a/packages/docs/src/mdx/themeCreator/ThemeCreator.tsx
+++ b/packages/docs/src/mdx/themeCreator/ThemeCreator.tsx
@@ -1,0 +1,337 @@
+import React, { useCallback, useMemo, useState } from 'react'
+import styled, { ThemeProvider } from 'styled-components'
+import { ColorPicker } from './ColorPicker'
+import {
+  AddIcon,
+  CheckIcon,
+  CloseIcon,
+  DownloadIcon,
+  InfoIcon,
+  MoreIcon,
+} from 'practical-react-components-icons'
+import {
+  palette,
+  Typography,
+  getHexValue,
+  defaultTheme,
+  IconTextButton,
+  Button,
+  Slider,
+  StrengthIndicator,
+  Chip,
+  DateTimePicker,
+  ColorName,
+  Paper,
+  Theme,
+  Color,
+  TextBlock,
+  TextInput,
+  Card,
+  CardHeader,
+  CardHeaderTypography,
+  CardContent,
+  CardFooter,
+  Menu,
+  Progress,
+  Spinner,
+  IconButton,
+  Tooltip,
+} from 'practical-react-components-core'
+import { H1, P } from '../Base'
+import { Code } from '../Code'
+
+const ThemeRow = styled.div`
+  border-bottom: ${({ theme }) => theme.color.element11()} 1px solid;
+  display: grid;
+  align-items: center;
+  grid-auto-flow: column;
+  grid-template-columns: 140px 95px 1fr 60px;
+`
+const Wrapper = styled.div`
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  grid-column-gap: 1%;
+`
+type SlotColors = Record<keyof Color, ColorName>
+
+const noop = () => {
+  /* noop */
+}
+
+const TopDocs = () => {
+  return (
+    <>
+      <H1>Theme Creator</H1>
+      <P>
+        With Theme-Creator you can generate a THEME file with custom colors by
+        changing the color of the &apos;slots&apos;.
+      </P>
+      <P>
+        Change a &apos;slot&apos; color by clicking on the color segment and
+        choosing a color from the Color-Picker.
+      </P>
+      <P>When the Preview has the desired look, download the file.</P>
+    </>
+  )
+}
+
+const BottomDocs = () => {
+  return (
+    <>
+      {' '}
+      <P>Using the file in your code:</P>
+      <Code className="code" type="code">
+        {`//App file\n
+        import { ThemeProvider } from "styled-components"
+        import { myCustomTheme } from "./pathTo<downloadedFile>"\n
+        <PracticalProvider>
+          <ThemeProvider theme={myCustomTheme}>
+            <App />
+          </ThemeProvider>
+        </PracticalProvider>`}
+      </Code>
+    </>
+  )
+}
+
+const generateTheme = (value: SlotColors): Theme => {
+  const arrayColors = Object.entries(value).map(([slot, colorName]) => [
+    slot,
+    palette[colorName],
+  ])
+
+  const objectColors = Object.fromEntries(arrayColors)
+  const themeValues: Theme = { ...defaultTheme, color: objectColors }
+
+  return themeValues
+}
+
+const getSlotColors = (): SlotColors => {
+  const namesAsArrays = Object.entries(defaultTheme.color).map(
+    ([slot, color]) => {
+      const colorName = Object.entries(palette).find(
+        ([, colorValue]) => color === colorValue
+      )?.[0]
+      return [slot, colorName]
+    }
+  )
+  const namesAsObject = Object.fromEntries(namesAsArrays)
+  return namesAsObject
+}
+
+export const ThemeCreator = () => {
+  const [slotColors, setSlotColors] = useState<SlotColors>(getSlotColors)
+  const [savedDefaultSlots] = useState<SlotColors>(getSlotColors)
+  const previewTheme = useMemo(() => generateTheme(slotColors), [slotColors])
+
+  const reset = useCallback(() => {
+    setSlotColors(savedDefaultSlots)
+  }, [savedDefaultSlots])
+
+  const triggerDownload = useCallback(() => {
+    const customColors = generateThemeFile(slotColors)
+    const filename = 'myCustomTheme.js'
+    download(filename, customColors)
+  }, [slotColors])
+
+  return (
+    <>
+      <TopDocs />
+      <Wrapper>
+        <Card>
+          <CardHeader style={{ justifyContent: 'space-between' }}>
+            <CardHeaderTypography>Color slots</CardHeaderTypography>
+            <Tooltip
+              verticalAlignment="bottom"
+              verticalPosition="top"
+              text="Reset colors"
+            >
+              <IconButton
+                icon={CloseIcon}
+                variant="secondary"
+                onClick={reset}
+              />
+            </Tooltip>
+          </CardHeader>
+          <CardContent>
+            {(
+              Object.entries(slotColors) as ReadonlyArray<
+                [keyof Color, ColorName]
+              >
+            ).map(([slot, colorName]) => (
+              <ThemeRow key={slot}>
+                <Typography>{slot}</Typography>
+                <PaletteColor
+                  slot={slot}
+                  colorName={colorName}
+                  // eslint-disable-next-line react/jsx-no-bind
+                  onChange={(slot2, nextColorName) => {
+                    setSlotColors(currentValue => ({
+                      ...currentValue,
+                      [slot2]: nextColorName,
+                    }))
+                  }}
+                />
+              </ThemeRow>
+            ))}
+          </CardContent>
+          <CardFooter>
+            <Button
+              icon={DownloadIcon}
+              onClick={triggerDownload}
+              label="Download file"
+            />
+          </CardFooter>
+        </Card>
+        <PreviewComponents theme={previewTheme} />
+      </Wrapper>
+      <BottomDocs />
+    </>
+  )
+}
+
+const download = (filename: string, content: string) => {
+  const element = document.createElement('a')
+  element.setAttribute(
+    'href',
+    `data:text/plain;charset=utf-8,${encodeURIComponent(content)}`
+  )
+  element.setAttribute('download', filename)
+  document.body.appendChild(element)
+  element.click()
+  document.body.removeChild(element)
+}
+
+interface PaletteColorProps {
+  readonly colorName: ColorName
+  readonly slot: keyof Color
+  readonly onChange: (slot: keyof Color, colorName: ColorName) => void
+}
+
+const PaletteColor: React.VFC<PaletteColorProps> = ({
+  slot,
+  colorName,
+  onChange,
+}) => {
+  const handleColorChange = useCallback(
+    nextColorName => {
+      onChange(slot, nextColorName)
+    },
+    [slot, onChange]
+  )
+  return (
+    <>
+      <Typography variant="default-text">{colorName}</Typography>
+      <ColorPicker onChange={handleColorChange} value={colorName} />
+      {colorName !== 'transparent' ? (
+        <Typography variant="explanatory-text">
+          {getHexValue(palette[colorName]())}
+        </Typography>
+      ) : (
+        <Typography variant="explanatory-text">trans</Typography>
+      )}
+    </>
+  )
+}
+
+const generateThemeFile = (value: SlotColors) => {
+  const colorsArray = Object.entries(value)
+    .map(([slot, colorName]) => `${slot}:palette.${colorName},\n`)
+    .join('')
+
+  const fileWithCode = `import { defaultTheme, palette } from 'practical-react-components-core'
+  export const myCustomTheme =  {
+  ...defaultTheme,
+  name: 'customTheme',
+  color: {\n${colorsArray}}
+}`
+
+  return fileWithCode
+}
+
+interface PreviewComponentsProps {
+  readonly theme: Theme
+}
+
+export const PreviewComponents: React.VFC<PreviewComponentsProps> = ({
+  theme,
+}) => {
+  const [open, setOpen] = useState(false)
+  const [currentDate, setCurrentDate] = useState(new Date().toISOString())
+  const toggle = () => {
+    setOpen(!open)
+  }
+  const save = useCallback(date => {
+    setOpen(false)
+    setCurrentDate(date)
+  }, [])
+  return (
+    <ThemeProvider theme={theme}>
+      <Card>
+        <CardHeader>
+          <CardHeaderTypography>Preview</CardHeaderTypography>
+        </CardHeader>
+        <Paper space={true} square={false}>
+          <TextBlock text="DateTimePicker" />
+          <Button
+            label="Change date and time"
+            variant="primary"
+            // eslint-disable-next-line react/jsx-no-bind
+            onClick={toggle}
+          />
+          <DateTimePicker
+            onSaveAction={{ label: 'Save', onClick: save }}
+            onCancelAction={{ label: 'Cancel', onClick: toggle }}
+            header="Change date and time"
+            date={currentDate}
+            open={open}
+            hour12={true}
+            hour12MeridiemLabels={{ am: 'AM', pm: 'PM' }}
+          />
+          <TextBlock text="Buttons" />
+          <IconTextButton icon={AddIcon} label="label" />
+          <Button icon={AddIcon} label="label" />
+          <Button icon={AddIcon} variant="secondary" label="label" />
+          <TextBlock text="Slider" />
+          <Slider value={50} handleChange={noop} />
+          <StrengthIndicator strength={0.25} helpText="bad" />
+          <StrengthIndicator strength={0.5} helpText="ok" />
+          <StrengthIndicator strength={0.75} helpText="good" />
+          <StrengthIndicator strength={1} helpText="excellent" />
+          <TextBlock text="Chip" />
+          <Chip text="good chip" />
+          <Chip text="bad chip" error={true} />
+          <Chip text="inactive chip" disabled={true} />
+          <Chip text="superlong text inside this super chip" />
+          <Chip text="with icon" icon={InfoIcon} />
+          <Chip text="can be removed" onRemove={noop} />
+          <TextBlock text="Text Input" />
+          <TextInput
+            value=""
+            onValueChange={noop}
+            placeholder="Placeholder"
+            width="large"
+          />
+          <TextBlock text="Menu" />
+          <Menu
+            icon={MoreIcon}
+            items={[
+              { icon: CheckIcon, label: 'Item 1', onClick: noop },
+              { label: 'Item 2', onClick: noop, divider: true },
+              {
+                label: 'Item 3',
+                onClick: noop,
+                disabled: true,
+                danger: true,
+              },
+            ]}
+          />
+          <TextBlock text="Progress" />
+          <Progress value={0.5} label="50%" />
+          <TextBlock text="Spinner" />
+          <Spinner type="primary" label="label" />
+        </Paper>
+      </Card>
+    </ThemeProvider>
+  )
+}


### PR DESCRIPTION
With Theme-Creator you can generate a `THEME`  file with custom colors by changing the color of the 'slots'.
(All the colors from `Palette` are eligible)

Change a 'slot' color by clicking on the color segment and choosing a color from the Color-Picker.

https://user-images.githubusercontent.com/67017215/122547654-ac244d80-d030-11eb-9a44-42e330ca5c99.mp4

When the Preview has the desired look, download the file.


https://user-images.githubusercontent.com/67017215/122547770-d1b15700-d030-11eb-8b56-cbbf2395c012.mp4


Then just paste the `file` in the project and `import` it from its respective `path`, 
Example:
```tsx
 import { myCustomTheme } from "./pathTo<downloadedFile>"

        <PracticalProvider>
          <ThemeProvider theme={myCustomTheme}>
            <App />
          </ThemeProvider>
        </PracticalProvider>
```


https://user-images.githubusercontent.com/67017215/122548198-5308e980-d031-11eb-93d0-3d88e6935cb7.mp4


