### PR TITLE
fix(chip): icon not clickable when Chip is disabled (#90)

### DIFF
--- a/packages/core/src/Chip/index.tsx
+++ b/packages/core/src/Chip/index.tsx
@@ -22,10 +22,11 @@ const ChipRemoveIcon = styled(ClickableIcon).attrs({
   tabIndex: 0,
   size: 'small',
   icon: CloseIcon,
-})`
+})<{ readonly disabled: boolean }>`
   flex: 0 0 min-content;
   overflow: visible;
   margin-left: ${spacing.small};
+  pointer-events: ${({ disabled }) => (disabled ? 'none' : undefined)};
 `
 
 interface ChipProps extends Omit<BaseChipProps, 'component' | 'noPadding'> {
@@ -46,17 +47,30 @@ interface ChipProps extends Omit<BaseChipProps, 'component' | 'noPadding'> {
 
 /* eslint-disable-next-line react/display-name */
 export const Chip = React.forwardRef<HTMLDivElement, ChipProps>(
-  ({ text, error = false, onRemove, icon, ...props }, ref) => {
+  (
+    { text, error = false, disabled = false, onRemove, icon, ...props },
+    ref
+  ) => {
     const component = useMemo(() => {
       return (
         <>
           {!error && icon !== undefined ? <ChipIcon icon={icon} /> : null}
           <Typography variant="chip-tag-text">{text}</Typography>
-          {onRemove ? <ChipRemoveIcon onClick={onRemove} /> : null}
+          {onRemove ? (
+            <ChipRemoveIcon disabled={disabled} onClick={onRemove} />
+          ) : null}
         </>
       )
-    }, [text, error, icon, onRemove])
+    }, [text, error, icon, onRemove, disabled])
 
-    return <BaseChip ref={ref} error={error} component={component} {...props} />
+    return (
+      <BaseChip
+        ref={ref}
+        disabled={disabled}
+        error={error}
+        component={component}
+        {...props}
+      />
+    )
   }
 )

--- a/packages/core/src/Select/__snapshots__/MultiSelect.test.tsx.snap
+++ b/packages/core/src/Select/__snapshots__/MultiSelect.test.tsx.snap
@@ -310,6 +310,7 @@ exports[`Select Direction 1`] = `
                   </span>
                   <span
                     className="c11 c12 c13"
+                    disabled={false}
                     onClick={[Function]}
                     role="img"
                     size="small"
@@ -710,6 +711,7 @@ exports[`Select Direction 2`] = `
                   </span>
                   <span
                     className="c11 c12 c13"
+                    disabled={false}
                     onClick={[Function]}
                     role="img"
                     size="small"
@@ -1117,6 +1119,7 @@ exports[`Select Other 1`] = `
                   </span>
                   <span
                     className="c11 c12 c13"
+                    disabled={false}
                     onClick={[Function]}
                     role="img"
                     size="small"
@@ -1531,6 +1534,7 @@ exports[`Select Other 2`] = `
                   </span>
                   <span
                     className="c11 c12 c13"
+                    disabled={false}
                     onClick={[Function]}
                     role="img"
                     size="small"
@@ -1931,6 +1935,7 @@ exports[`Select Width 1`] = `
                   </span>
                   <span
                     className="c11 c12 c13"
+                    disabled={false}
                     onClick={[Function]}
                     role="img"
                     size="small"
@@ -2331,6 +2336,7 @@ exports[`Select Width 2`] = `
                   </span>
                   <span
                     className="c11 c12 c13"
+                    disabled={false}
                     onClick={[Function]}
                     role="img"
                     size="small"
@@ -2363,6 +2369,7 @@ exports[`Select Width 2`] = `
                   </span>
                   <span
                     className="c11 c12 c13"
+                    disabled={false}
                     onClick={[Function]}
                     role="img"
                     size="small"
@@ -2763,6 +2770,7 @@ exports[`Select Width 3`] = `
                   </span>
                   <span
                     className="c11 c12 c13"
+                    disabled={false}
                     onClick={[Function]}
                     role="img"
                     size="small"
@@ -2795,6 +2803,7 @@ exports[`Select Width 3`] = `
                   </span>
                   <span
                     className="c11 c12 c13"
+                    disabled={false}
                     onClick={[Function]}
                     role="img"
                     size="small"


### PR DESCRIPTION
Fixes #90

Old behavior:

![image](https://user-images.githubusercontent.com/67017215/123137880-c016e780-d454-11eb-898e-741c05275268.png)

Current behavior:

![image](https://user-images.githubusercontent.com/67017215/123138196-0cfabe00-d455-11eb-9c7a-29aceaed88b3.png)
