### PR TITLE
fix(toast): correctly wrap label if word

### DIFF
--- a/packages/core/src/Toast/Toast.tsx
+++ b/packages/core/src/Toast/Toast.tsx
@@ -63,6 +63,7 @@ const LabelContainer = styled.div`
 
   overflow: hidden;
   text-overflow: ellipsis;
+  word-wrap: break-word;
 `
 
 const MessageContainer = styled.div`


### PR DESCRIPTION
Correctly wraps toast label if label is a long word eg
`thisisareallylongwordthatneedstobeclampedandwrappedwithanelipsis`

![image](https://user-images.githubusercontent.com/1503783/131136139-3382d003-ab25-4ee0-9eaf-11c8677359c2.png)
