### PR TITLE
fix(slider): align min and max tick labels

### DIFF
--- a/packages/core/src/Slider/Tick.tsx
+++ b/packages/core/src/Slider/Tick.tsx
@@ -66,8 +66,25 @@ const BaseLabel = styled.div.attrs<{
   readonly center: number
   readonly width: number
 }>(({ center, width }) => ({
-  style: { left: `calc(${center}% - ${width / 2}px)` },
-}))<{ readonly center: number; readonly width: number }>`
+  style: (() => {
+    if (center === 0) {
+      return {
+        left: 0,
+      }
+    }
+
+    if (center === 100) {
+      return { right: 0 }
+    }
+
+    return {
+      left: `calc(${center}% - ${width / 2}px)`,
+    }
+  })(),
+}))<{
+  readonly center: number
+  readonly width: number
+}>`
   position: absolute;
   cursor: pointer;
 


### PR DESCRIPTION
Introduces a fix that aligns minimum and maximum labels left and right.

![slider_left_right_label_aligned](https://user-images.githubusercontent.com/77433590/131997767-2d07b096-f085-4ee7-bdc8-868f8449a2a1.png)
