### PR TITLE
feat(table): double-click resizes adjacent columns

### DIFF
--- a/packages/core/src/Table/Table.tsx
+++ b/packages/core/src/Table/Table.tsx
@@ -8,7 +8,6 @@ import React, {
   useState,
 } from 'react'
 import styled from 'styled-components'
-
 import { spacing } from '../designparams'
 
 import { ColumnResizerRow } from './ColumnResizerRow'
@@ -168,6 +167,7 @@ const reduceWidths = (state: WidthsState, action: WidthAction): WidthsState => {
  * Example:
  *  [34, 78]
  */
+
 export const useGridTemplateColumns = () => {
   const { columnWidths, selectWidth, menuWidth } = useContext(TableContext)
 
@@ -273,6 +273,8 @@ export interface TableProps extends Omit<BaseProps, 'onSelect'> {
   /**
    * Control if columns should be resizeable or not. If true, resize
    * handles will be available to change column width.
+   *
+   * For doubleclick functionality to work properly, when you have multiple elements in one cell, wrap them inside a <div>.
    *
    * @default false
    */
@@ -409,6 +411,7 @@ export const Table: React.FunctionComponent<TableProps> = React.memo(
             onSelect,
             hasMenu,
             onWidthsChange,
+            tableRef,
           }}
         >
           <TableHeaderContainer>{header}</TableHeaderContainer>

--- a/packages/core/src/Table/TableHeader.tsx
+++ b/packages/core/src/Table/TableHeader.tsx
@@ -95,7 +95,11 @@ export const TableHeader: React.FC<TableHeaderProps> = ({
         <OverlayContainer>{overlay}</OverlayContainer>
       ) : (
         React.Children.map(children, (cell, i) => {
-          return <TableHeaderCellContent key={i}>{cell}</TableHeaderCellContent>
+          return (
+            <TableHeaderCellContent data-col={i} key={i}>
+              {cell}
+            </TableHeaderCellContent>
+          )
         })
       )}
       {overlay === undefined && hasMenu ? (

--- a/packages/core/src/Table/TableRow.tsx
+++ b/packages/core/src/Table/TableRow.tsx
@@ -162,7 +162,11 @@ export const TableRow: React.FC<TableRowProps> = React.memo(
 
     const tableCellContent = useMemo(() => {
       return React.Children.map(children, (cell, cellId) => {
-        return <TableCellContent key={cellId}>{cell}</TableCellContent>
+        return (
+          <TableCellContent data-col={cellId} key={cellId}>
+            {cell}
+          </TableCellContent>
+        )
       })
     }, [children])
 

--- a/packages/core/src/Table/__snapshots__/index.test.tsx.snap
+++ b/packages/core/src/Table/__snapshots__/index.test.tsx.snap
@@ -453,6 +453,7 @@ exports[`Tables Table (minimal) 1`] = `
           >
             <div
               className="c5 c6 c7"
+              data-col={0}
             >
               <p
                 className="c8 c9"
@@ -462,6 +463,7 @@ exports[`Tables Table (minimal) 1`] = `
             </div>
             <div
               className="c5 c6 c7"
+              data-col={1}
             >
               <p
                 className="c8 c9"
@@ -471,6 +473,7 @@ exports[`Tables Table (minimal) 1`] = `
             </div>
             <div
               className="c5 c6 c7"
+              data-col={2}
             >
               <p
                 className="c8 c9"

--- a/packages/core/src/Table/context.ts
+++ b/packages/core/src/Table/context.ts
@@ -52,6 +52,7 @@ export const TableContext = createContext<{
   readonly onSelect?: (selected: boolean, id?: string) => void
   readonly hasMenu: boolean
   readonly onWidthsChange?: (widths: ReadonlyArray<number>) => void
+  readonly tableRef?: React.RefObject<HTMLDivElement>
 }>({
   minColumnWidth: 0,
   columnWidths: [],


### PR DESCRIPTION
Double clicking a divider resizes the two adjacent columns to fit their content.

Fixes #85 