### PR TITLE
fix(slider): limit slider value

### DIFF
--- a/packages/core/src/Slider/index.tsx
+++ b/packages/core/src/Slider/index.tsx
@@ -340,7 +340,10 @@ export const Slider: React.FC<SliderProps> = ({
     }
   }, [tickConfig])
 
-  const fraction = (value - min) / (max - min)
+  const fraction = useMemo(
+    () => clamp((value - min) / (max - min)),
+    [max, min, value]
+  )
 
   // Generate the ticks with its position along the x-axis
   const tickMarkers = useMemo(


### PR DESCRIPTION
Limits the slider value to min and max values
![limit slider value](https://user-images.githubusercontent.com/77433590/134513447-e6cfc0bc-3ec4-4c93-a450-1ea894e53065.gif)


