### PR TITLE
chore: updated accepted types in commits

### DIFF
--- a/sbin/changelog.py
+++ b/sbin/changelog.py
@@ -24,12 +24,17 @@ GITHUB_COMMIT_URL = (
 )
 
 GROUP_TITLES = {
-    "feat": "🚀 Features",
-    "fix": "🐛 Bug fixes",
-    "refactor": "🧰 Refactoring",
-    "docs": "📝 Documentation",
+    "build": "👷 Build",
     "chore": "🚧 Maintenance",
     "ci": "🚦 Continous integration",
+    "docs": "📝 Documentation",
+    "feat": "✨ Features",
+    "fix": "🐛 Bug fixes",
+    "perf": "🏎️ Performance",
+    "refactor": "♻️ Refactoring",
+    "revert": "⏪️ Reverts",
+    "style": "💄 Styling",
+    "test": "🧪 Test",
 }
 
 

--- a/sbin/utils.py
+++ b/sbin/utils.py
@@ -3,7 +3,19 @@ import subprocess
 import sys
 import typing
 
-possible_types = ["feat", "fix", "refactor", "docs", "chore", "ci"]
+possible_types = [
+    "build",
+    "chore",
+    "ci",
+    "docs",
+    "feat",
+    "fix",
+    "perf",
+    "refactor",
+    "revert",
+    "style",
+    "test",
+]
 
 types = "|".join(possible_types)
 
@@ -27,7 +39,7 @@ def conventional_commit_parse(message: str):
 
 
 def cmd(cmd: typing.List[str]) -> str:
-    """ Call shell command and return the result """
+    """Call shell command and return the result"""
     try:
         return subprocess.check_output(cmd, encoding="utf-8").strip()
     except subprocess.CalledProcessError as exc:


### PR DESCRIPTION
Allow all types following [conventional commits ](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)