### PR TITLE
fix(table): hover effect does not stay on table row when menu on table row active

### DIFF
--- a/packages/core/src/Table/TableRow.tsx
+++ b/packages/core/src/Table/TableRow.tsx
@@ -60,6 +60,11 @@ const TableRowGrid = styled.div<{
     }
   }
 
+  &:focus-within {
+    box-shadow: ${({ theme }) => theme.shadow.tableRow};
+    z-index: 1;
+  }
+
   &.selected {
     background-color: ${({ theme }) => theme.color.backgroundPrimary()};
   }


### PR DESCRIPTION
Closes #138

|Before|After|
|--|--|
|![table-shadow_before](https://user-images.githubusercontent.com/24866179/144590303-3fc92fbf-bda5-4e3a-92a4-36b4bd886959.gif)| ![table-shadow_after](https://user-images.githubusercontent.com/24866179/144589373-4c309f3f-e277-4dae-8b42-64831bda0c6f.gif)|