### PR TITLE
fix(searchSelect): set isTyping to false on blur

### DIFF
--- a/packages/core/src/Select/SearchSelect.tsx
+++ b/packages/core/src/Select/SearchSelect.tsx
@@ -94,10 +94,10 @@ export function SearchSelect<V extends string = string>({
 
   const selectInputText = useCallback(() => inputRef.current?.select(), [])
 
-  const resetInputText = useCallback(
-    () => setFilter(getLabel(currentValue, options)),
-    [currentValue, options]
-  )
+  const resetInputText = useCallback(() => {
+    setFilter(getLabel(currentValue, options))
+    stopTyping()
+  }, [currentValue, options])
 
   useEffect(
     () => setFilter(getLabel(currentValue, options)),


### PR DESCRIPTION
When user leaves the input, `isTyping` should be set to `false`.

Before:
![searchselect_before](https://user-images.githubusercontent.com/1014308/142421093-0070e90c-f5a0-4bdc-a65c-e1c555c2cca0.gif)

After:
![searchselect_after](https://user-images.githubusercontent.com/1014308/142421198-3911cd09-c4db-4a35-a992-ed5730d5de88.gif)

