### PR TITLE
chore(docs): github repository link

### DIFF
--- a/packages/docs/src/Menu.tsx
+++ b/packages/docs/src/Menu.tsx
@@ -6,7 +6,12 @@ import {
   ExpandableListItemType,
   IconButton,
 } from 'practical-react-components-core'
-import { HamburgerMenuIcon } from 'practical-react-components-icons'
+import {
+  DownloadIcon,
+  HamburgerMenuIcon,
+  HomeIcon,
+  LogIcon,
+} from 'practical-react-components-icons'
 
 import { Components, Component } from './types'
 
@@ -14,11 +19,18 @@ const BASE_ITEMS = [
   {
     name: 'Home',
     route: '/',
+    icon: HomeIcon,
+  },
+  {
+    name: 'Repository',
+    route: 'https://github.com/AxisCommunications/practical-react-components',
+    icon: DownloadIcon,
   },
   {
     name: 'Changelog',
     route:
       'https://github.com/AxisCommunications/practical-react-components/blob/main/CHANGELOG.md',
+    icon: LogIcon,
   },
 ]
 
@@ -83,7 +95,7 @@ export const Menu: React.FC<MenuProps> = ({ components }) => {
       [...BASE_ITEMS, ...components].map(c => ({
         id: c.name,
         label: c.name,
-        icon: () => null,
+        icon: () => c.icon ?? null,
         selected: matchPath(location.pathname, c.route) !== null,
         onClick: () =>
           /^https?:\/\//.test(c.route)

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -1,7 +1,10 @@
+import { IconType } from 'practical-react-components-core'
+
 export interface Component {
   readonly name: string
   readonly route: string
   readonly menu: string
+  readonly icon?: IconType
   readonly component: React.FC
 }
 


### PR DESCRIPTION
Adds a menu link to the github repository. Also adds the ability to use icons for the menu choices and adds icons for Home and
Changelog menu items.

![Screenshot from 2021-11-23 14-59-50](https://user-images.githubusercontent.com/7765599/143037788-2c9cc185-0a2d-4bdb-9df4-dfe214de49de.png)
