### PR TITLE
fix(menu): prevent closing menu when you click an item that has a submenu

### DIFF
--- a/packages/core/src/Menu/BaseMenu.tsx
+++ b/packages/core/src/Menu/BaseMenu.tsx
@@ -422,6 +422,12 @@ const BaseItemWithSubmenu: React.FunctionComponent<
     e.preventDefault()
   }, [])
 
+  const preventCloseMenu = useCallback(e => {
+    // Prevent event from bubbling up to the wrapper
+    // that closes the menu when it has submenu
+    e.stopPropagation()
+  }, [])
+
   return (
     <>
       <BaseMenuItem
@@ -431,6 +437,7 @@ const BaseItemWithSubmenu: React.FunctionComponent<
         onPointerDown={preventMenuBlur}
         onPointerOver={show}
         onPointerOut={hide}
+        onClick={preventCloseMenu}
       >
         {component}
       </BaseMenuItem>


### PR DESCRIPTION
Before
![menu-close-on-click](https://user-images.githubusercontent.com/24866179/151219127-2c4ad7bc-6c46-4627-b84e-ab378e9ccb97.gif)

After
![not-close-menu](https://user-images.githubusercontent.com/24866179/151219153-de6129dd-70c9-4468-88df-8f111b00cc44.gif)
