### PR TITLE
fix(select): apply overflow hidden to MultiSelect chips

### DIFF
--- a/packages/core/src/Select/MultiSelect.tsx
+++ b/packages/core/src/Select/MultiSelect.tsx
@@ -46,12 +46,14 @@ const SelectInsideContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  overflow: hidden;
 `
 
 const ChipContainer = styled.div`
   display: flex;
   flex-grow: 1;
   flex-wrap: wrap;
+  overflow: hidden;
 `
 
 const IconsContainer = styled.div`

--- a/packages/core/src/Select/__snapshots__/MultiSelect.test.tsx.snap
+++ b/packages/core/src/Select/__snapshots__/MultiSelect.test.tsx.snap
@@ -218,6 +218,7 @@ exports[`Select Direction 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  overflow: hidden;
 }
 
 .c7 {
@@ -232,6 +233,7 @@ exports[`Select Direction 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  overflow: hidden;
 }
 
 .c14 {
@@ -609,6 +611,7 @@ exports[`Select Direction 2`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  overflow: hidden;
 }
 
 .c7 {
@@ -623,6 +626,7 @@ exports[`Select Direction 2`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  overflow: hidden;
 }
 
 .c14 {
@@ -1007,6 +1011,7 @@ exports[`Select Other 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  overflow: hidden;
 }
 
 .c7 {
@@ -1021,6 +1026,7 @@ exports[`Select Other 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  overflow: hidden;
 }
 
 .c14 {
@@ -1412,6 +1418,7 @@ exports[`Select Other 2`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  overflow: hidden;
 }
 
 .c7 {
@@ -1426,6 +1433,7 @@ exports[`Select Other 2`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  overflow: hidden;
 }
 
 .c14 {
@@ -1803,6 +1811,7 @@ exports[`Select Width 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  overflow: hidden;
 }
 
 .c7 {
@@ -1817,6 +1826,7 @@ exports[`Select Width 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  overflow: hidden;
 }
 
 .c14 {
@@ -2194,6 +2204,7 @@ exports[`Select Width 2`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  overflow: hidden;
 }
 
 .c7 {
@@ -2208,6 +2219,7 @@ exports[`Select Width 2`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  overflow: hidden;
 }
 
 .c14 {
@@ -2617,6 +2629,7 @@ exports[`Select Width 3`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  overflow: hidden;
 }
 
 .c7 {
@@ -2631,6 +2644,7 @@ exports[`Select Width 3`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
+  overflow: hidden;
 }
 
 .c14 {


### PR DESCRIPTION
Apply `overflow: hidden` to the chips inside the multiselect so that it does not grow unnecessary and pushes its internal components outside the container.

Fixes: #195

<img width="481" alt="Screenshot 2022-02-21 at 12 25 57" src="https://user-images.githubusercontent.com/2505557/154946933-b8582ea2-296d-4107-9d1f-cdb9ad3478a3.png">

<img width="344" alt="Screenshot 2022-02-21 at 12 26 05" src="https://user-images.githubusercontent.com/2505557/154947003-ba7b1c06-3086-4022-ba3c-411dd7bcd98b.png">

<img width="265" alt="Screenshot 2022-02-21 at 12 26 15" src="https://user-images.githubusercontent.com/2505557/154947019-37285266-074c-4f2f-8632-a326d9ec8734.png">

