### PR TITLE
refactor(draggable): moves drag handle inside `DraggableListItem`

### DIFF
--- a/packages/core/src/DraggableList/__snapshots__/index.test.tsx.snap
+++ b/packages/core/src/DraggableList/__snapshots__/index.test.tsx.snap
@@ -41,11 +41,6 @@ exports[`DraggableList DraggableList 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  width: 100%;
   height: 48px;
 }
 
@@ -68,6 +63,11 @@ exports[`DraggableList DraggableList 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  width: 100%;
 }
 
 .c8 {
@@ -120,30 +120,32 @@ exports[`DraggableList DraggableList 1`] = `
               className="c3"
               disabled={false}
             >
-              <p>
-                1
-              </p>
-            </div>
-            <div
-              className="c4"
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-            >
-              <span
-                className="c5"
-                role="img"
-                size="medium"
+              <div>
+                <p>
+                  1
+                </p>
+              </div>
+              <div
+                className="c4"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
               >
-                <svg
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  width="1em"
+                <span
+                  className="c5"
+                  role="img"
+                  size="medium"
                 >
-                  <path
-                    d="m20 9h-16v2h16v-2zm-16 6h16v-2h-16v2z"
-                  />
-                </svg>
-              </span>
+                  <svg
+                    height="1em"
+                    viewBox="0 0 24 24"
+                    width="1em"
+                  >
+                    <path
+                      d="m20 9h-16v2h16v-2zm-16 6h16v-2h-16v2z"
+                    />
+                  </svg>
+                </span>
+              </div>
             </div>
           </div>
           <div
@@ -167,30 +169,32 @@ exports[`DraggableList DraggableList 1`] = `
               className="c3"
               disabled={false}
             >
-              <p>
-                2
-              </p>
-            </div>
-            <div
-              className="c4"
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-            >
-              <span
-                className="c5"
-                role="img"
-                size="medium"
+              <div>
+                <p>
+                  2
+                </p>
+              </div>
+              <div
+                className="c4"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
               >
-                <svg
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  width="1em"
+                <span
+                  className="c5"
+                  role="img"
+                  size="medium"
                 >
-                  <path
-                    d="m20 9h-16v2h16v-2zm-16 6h16v-2h-16v2z"
-                  />
-                </svg>
-              </span>
+                  <svg
+                    height="1em"
+                    viewBox="0 0 24 24"
+                    width="1em"
+                  >
+                    <path
+                      d="m20 9h-16v2h16v-2zm-16 6h16v-2h-16v2z"
+                    />
+                  </svg>
+                </span>
+              </div>
             </div>
           </div>
           <div
@@ -214,30 +218,32 @@ exports[`DraggableList DraggableList 1`] = `
               className="c3"
               disabled={false}
             >
-              <p>
-                3
-              </p>
-            </div>
-            <div
-              className="c4"
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-            >
-              <span
-                className="c5"
-                role="img"
-                size="medium"
+              <div>
+                <p>
+                  3
+                </p>
+              </div>
+              <div
+                className="c4"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
               >
-                <svg
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  width="1em"
+                <span
+                  className="c5"
+                  role="img"
+                  size="medium"
                 >
-                  <path
-                    d="m20 9h-16v2h16v-2zm-16 6h16v-2h-16v2z"
-                  />
-                </svg>
-              </span>
+                  <svg
+                    height="1em"
+                    viewBox="0 0 24 24"
+                    width="1em"
+                  >
+                    <path
+                      d="m20 9h-16v2h16v-2zm-16 6h16v-2h-16v2z"
+                    />
+                  </svg>
+                </span>
+              </div>
             </div>
           </div>
           <div
@@ -260,9 +266,11 @@ exports[`DraggableList DraggableList 1`] = `
               className="c3"
               disabled={true}
             >
-              <p>
-                4
-              </p>
+              <div>
+                <p>
+                  4
+                </p>
+              </div>
             </div>
           </div>
           <div
@@ -286,30 +294,32 @@ exports[`DraggableList DraggableList 1`] = `
               className="c3"
               disabled={false}
             >
-              <p>
-                5
-              </p>
-            </div>
-            <div
-              className="c4"
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-            >
-              <span
-                className="c5"
-                role="img"
-                size="medium"
+              <div>
+                <p>
+                  5
+                </p>
+              </div>
+              <div
+                className="c4"
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
               >
-                <svg
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  width="1em"
+                <span
+                  className="c5"
+                  role="img"
+                  size="medium"
                 >
-                  <path
-                    d="m20 9h-16v2h16v-2zm-16 6h16v-2h-16v2z"
-                  />
-                </svg>
-              </span>
+                  <svg
+                    height="1em"
+                    viewBox="0 0 24 24"
+                    width="1em"
+                  >
+                    <path
+                      d="m20 9h-16v2h16v-2zm-16 6h16v-2h-16v2z"
+                    />
+                  </svg>
+                </span>
+              </div>
             </div>
           </div>
           <div

--- a/packages/core/src/DraggableList/index.tsx
+++ b/packages/core/src/DraggableList/index.tsx
@@ -20,8 +20,6 @@ type BaseProps = React.HTMLAttributes<BaseElement>
 const DraggableItem = styled.div`
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  width: 100%;
   height: ${componentSize.large};
 `
 
@@ -36,14 +34,51 @@ const DragHandleIcon = () => (
   </svg>
 )
 
-export const DraggableListItem = styled.div<{
+const DraggableListItemStyled = styled.div<{
   readonly disabled?: boolean
 }>`
   display: flex;
   height: 100%;
   flex-grow: 1;
   align-items: center;
+  justify-content: space-between;
+  width: 100%;
 `
+
+interface DraggableListItemProps extends BaseProps {
+  readonly disabled?: boolean
+  readonly className?: string
+}
+
+export const DraggableListItem: React.FC<DraggableListItemProps> = ({
+  children,
+  ...props
+}) => {
+  const onGrabHandle = useCallback<MouseEventHandler<HTMLDivElement>>(e => {
+    e.currentTarget.parentElement?.parentElement?.setAttribute(
+      'draggable',
+      'true'
+    )
+  }, [])
+
+  const onReleaseHandle = useCallback<MouseEventHandler<HTMLDivElement>>(e => {
+    e.currentTarget.parentElement?.parentElement?.setAttribute(
+      'draggable',
+      'false'
+    )
+  }, [])
+
+  return (
+    <DraggableListItemStyled {...props}>
+      <div>{children}</div>
+      {props.disabled === true ? null : (
+        <DraggableHandle onMouseDown={onGrabHandle} onMouseUp={onReleaseHandle}>
+          <Icon icon={DragHandleIcon} />
+        </DraggableHandle>
+      )}
+    </DraggableListItemStyled>
+  )
+}
 
 /**
  * Draggable list
@@ -120,18 +155,6 @@ export const DraggableList: React.FC<DraggableListProps> = ({
     onChange(order)
   }, [order, onChange])
 
-  const onGrabHandle = useCallback<MouseEventHandler<HTMLDivElement>>(e => {
-    if (e.currentTarget.parentElement !== null) {
-      e.currentTarget.parentElement.setAttribute('draggable', 'true')
-    }
-  }, [])
-
-  const onReleaseHandle = useCallback<MouseEventHandler<HTMLDivElement>>(e => {
-    if (e.currentTarget.parentElement !== null) {
-      e.currentTarget.parentElement.setAttribute('draggable', 'false')
-    }
-  }, [])
-
   return (
     <div {...props}>
       {order.map((childIndex, index) => {
@@ -150,14 +173,6 @@ export const DraggableList: React.FC<DraggableListProps> = ({
               }}
             >
               {el}
-              {isLocked ? null : (
-                <DraggableHandle
-                  onMouseDown={onGrabHandle}
-                  onMouseUp={onReleaseHandle}
-                >
-                  <Icon icon={DragHandleIcon} />
-                </DraggableHandle>
-              )}
             </DraggableItem>
             <Divider />
           </div>


### PR DESCRIPTION
Moves drag handle inside `DraggableListItem` so it can be easily styled, for example, wrapped in the border.
No functionality or design changes.

Before:
<img width="856" alt="before" src="https://user-images.githubusercontent.com/2505557/155519683-7921ae1d-7f7a-4730-a586-f41bfb03bf2a.png">

After:
<img width="838" alt="after" src="https://user-images.githubusercontent.com/2505557/155519698-91d9c697-5947-453f-8a7f-2adb1c4f69bb.png">

