### PR TITLE
feat(selectList): change value with keyboard up/down

### DIFF
--- a/packages/core/src/SelectList/__snapshots__/index.test.tsx.snap
+++ b/packages/core/src/SelectList/__snapshots__/index.test.tsx.snap
@@ -136,6 +136,7 @@ exports[`SelectList SelectList 1`] = `
     >
       <ul
         className="c2"
+        onKeyDown={[Function]}
         onKeyUp={[Function]}
         tabIndex={0}
       >
@@ -333,6 +334,7 @@ exports[`SelectList SelectList 2`] = `
     >
       <ul
         className="c2"
+        onKeyDown={[Function]}
         onKeyUp={[Function]}
         tabIndex={0}
       >


### PR DESCRIPTION
When the select list has focus, the key up and down key will change the
selected value instead of scrolling the list.

It would be good if the list would have some focus glow around it. But that's a task for a new commit.