### PR TITLE
feat(multiSelect): remove selected options with keyboard

### DIFF
--- a/packages/core/src/Chip/index.tsx
+++ b/packages/core/src/Chip/index.tsx
@@ -1,6 +1,6 @@
 export * from './BaseChip'
 
-import React, { useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import styled from 'styled-components'
 
 import { CloseIcon } from 'practical-react-components-icons'
@@ -42,18 +42,34 @@ export interface ChipProps
    * Function to call if remove icon is pressed. Remove icon
    * only visible if this prop is set.
    */
-  readonly onRemove?: (e: React.MouseEvent) => void
+  readonly onRemove?: () => void
 }
 
 /* eslint-disable-next-line react/display-name */
 export const Chip = React.forwardRef<HTMLDivElement, ChipProps>(
   ({ text, error = false, onRemove, icon, ...props }, ref) => {
+    const handleKeyDown = useCallback(
+      (event: React.KeyboardEvent<HTMLSpanElement>) => {
+        if (onRemove === undefined) {
+          return
+        }
+
+        if (event.key === 'Enter') {
+          event.stopPropagation()
+          onRemove()
+        }
+      },
+      [onRemove]
+    )
+
     const component = useMemo(() => {
       return (
         <>
           {!error && icon !== undefined ? <ChipIcon icon={icon} /> : null}
           <Typography variant="chip-tag-text">{text}</Typography>
-          {onRemove ? <ChipRemoveIcon onClick={onRemove} /> : null}
+          {onRemove ? (
+            <ChipRemoveIcon onClick={onRemove} onKeyDown={handleKeyDown} />
+          ) : null}
         </>
       )
     }, [text, error, icon, onRemove])

--- a/packages/core/src/Select/MultiSelect.tsx
+++ b/packages/core/src/Select/MultiSelect.tsx
@@ -84,6 +84,15 @@ export function MultiSelect<V extends string = string>({
     },
     [onChange]
   )
+  const handleRemoveAllKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLSpanElement>) => {
+      if (event.key === 'Enter') {
+        event.stopPropagation()
+        onChange?.([])
+      }
+    },
+    [onChange]
+  )
 
   const onMultiChange = useCallback(
     nextValue => onChange?.([...value, nextValue]),
@@ -95,8 +104,7 @@ export function MultiSelect<V extends string = string>({
     () =>
       value.map(v => ({
         label: options.find(option => option.value === v)?.label ?? '',
-        onRemove: (e: React.MouseEvent) => {
-          e.stopPropagation()
+        onRemove: () => {
           onChange?.(value.filter(v2 => v2 !== v))
         },
       })),
@@ -124,12 +132,13 @@ export function MultiSelect<V extends string = string>({
             size="small"
             icon={CloseIcon}
             onClick={onRemoveAllClick}
+            onKeyDown={handleRemoveAllKeyDown}
           />
         </IconsContainer>
         <Divider />
       </SelectInsideContainer>
     )
-  }, [chips, onRemoveAllClick, placeholder, value])
+  }, [chips, onRemoveAllClick, handleRemoveAllKeyDown, placeholder, value])
 
   const notSelectedOptions = useMemo(
     () =>

--- a/packages/core/src/Select/__snapshots__/MultiSelect.test.tsx.snap
+++ b/packages/core/src/Select/__snapshots__/MultiSelect.test.tsx.snap
@@ -304,6 +304,7 @@ exports[`Select Direction 1`] = `
                   <span
                     className="c11 c12 c13"
                     onClick={[Function]}
+                    onKeyDown={[Function]}
                     role="img"
                     size="small"
                     tabIndex={0}
@@ -331,6 +332,7 @@ exports[`Select Direction 1`] = `
                 <span
                   className="c11 c12"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
                   role="img"
                   size="small"
                   tabIndex={0}
@@ -697,6 +699,7 @@ exports[`Select Direction 2`] = `
                   <span
                     className="c11 c12 c13"
                     onClick={[Function]}
+                    onKeyDown={[Function]}
                     role="img"
                     size="small"
                     tabIndex={0}
@@ -724,6 +727,7 @@ exports[`Select Direction 2`] = `
                 <span
                   className="c11 c12"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
                   role="img"
                   size="small"
                   tabIndex={0}
@@ -1097,6 +1101,7 @@ exports[`Select Other 1`] = `
                   <span
                     className="c11 c12 c13"
                     onClick={[Function]}
+                    onKeyDown={[Function]}
                     role="img"
                     size="small"
                     tabIndex={0}
@@ -1124,6 +1129,7 @@ exports[`Select Other 1`] = `
                 <span
                   className="c11 c12"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
                   role="img"
                   size="small"
                   tabIndex={0}
@@ -1504,6 +1510,7 @@ exports[`Select Other 2`] = `
                   <span
                     className="c11 c12 c13"
                     onClick={[Function]}
+                    onKeyDown={[Function]}
                     role="img"
                     size="small"
                     tabIndex={0}
@@ -1531,6 +1538,7 @@ exports[`Select Other 2`] = `
                 <span
                   className="c11 c12"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
                   role="img"
                   size="small"
                   tabIndex={0}
@@ -1897,6 +1905,7 @@ exports[`Select Width 1`] = `
                   <span
                     className="c11 c12 c13"
                     onClick={[Function]}
+                    onKeyDown={[Function]}
                     role="img"
                     size="small"
                     tabIndex={0}
@@ -1924,6 +1933,7 @@ exports[`Select Width 1`] = `
                 <span
                   className="c11 c12"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
                   role="img"
                   size="small"
                   tabIndex={0}
@@ -2290,6 +2300,7 @@ exports[`Select Width 2`] = `
                   <span
                     className="c11 c12 c13"
                     onClick={[Function]}
+                    onKeyDown={[Function]}
                     role="img"
                     size="small"
                     tabIndex={0}
@@ -2322,6 +2333,7 @@ exports[`Select Width 2`] = `
                   <span
                     className="c11 c12 c13"
                     onClick={[Function]}
+                    onKeyDown={[Function]}
                     role="img"
                     size="small"
                     tabIndex={0}
@@ -2349,6 +2361,7 @@ exports[`Select Width 2`] = `
                 <span
                   className="c11 c12"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
                   role="img"
                   size="small"
                   tabIndex={0}
@@ -2715,6 +2728,7 @@ exports[`Select Width 3`] = `
                   <span
                     className="c11 c12 c13"
                     onClick={[Function]}
+                    onKeyDown={[Function]}
                     role="img"
                     size="small"
                     tabIndex={0}
@@ -2747,6 +2761,7 @@ exports[`Select Width 3`] = `
                   <span
                     className="c11 c12 c13"
                     onClick={[Function]}
+                    onKeyDown={[Function]}
                     role="img"
                     size="small"
                     tabIndex={0}
@@ -2774,6 +2789,7 @@ exports[`Select Width 3`] = `
                 <span
                   className="c11 c12"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
                   role="img"
                   size="small"
                   tabIndex={0}


### PR DESCRIPTION
Add `Enter` key down event listeners on the remove icons. So that the control can be controlled with keyboard and not require a mouse.