### PR TITLE
feat(stepper): make completeAction prop optional

### DIFF
--- a/packages/core/src/Stepper/Step.tsx
+++ b/packages/core/src/Stepper/Step.tsx
@@ -153,7 +153,7 @@ interface StepProps extends Omit<StepContent, 'content'> {
   /**
    * The function that run on action button click in the last stepper step.
    */
-  readonly completeAction: StepperAction
+  readonly completeAction?: StepperAction
   /**
    * The function that runs on previous button click.
    */
@@ -240,7 +240,7 @@ export const Step: React.FC<StepProps> = ({
         setCurrentStep(-1)
       }
 
-      if (completeAction.onClick !== undefined) {
+      if (completeAction?.onClick !== undefined) {
         completeAction.onClick(event)
       }
     },
@@ -299,7 +299,7 @@ export const Step: React.FC<StepProps> = ({
                 disabled={disableNext}
               />
             )}
-            {lastStep ? (
+            {lastStep && completeAction !== undefined ? (
               <Button
                 onClick={onCompleteButtonClick}
                 label={completeAction.label}

--- a/packages/core/src/Stepper/index.tsx
+++ b/packages/core/src/Stepper/index.tsx
@@ -27,7 +27,7 @@ export interface StepperProps extends BaseProps {
   /**
    * The function that run on action button click in the last stepper step.
    */
-  readonly completeAction: StepperAction
+  readonly completeAction?: StepperAction
   /**
    * The function that runs on previous button click.
    */


### PR DESCRIPTION
### Describe your changes

Updated the `completeAction` prop in stepper to be optional. In some cases you might not need a save button or want to place it in a different location/component.

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
