### PR TITLE
feat(toast): adds the option to remove the close button

### DIFF
--- a/packages/core/src/Toast/context.ts
+++ b/packages/core/src/Toast/context.ts
@@ -7,6 +7,7 @@ export interface SimpleToast {
   readonly message?: string
   readonly onClose?: (id: ToastId) => void
   readonly duration?: number
+  readonly hasCloseButton?: boolean
 }
 
 export interface ActionToast extends SimpleToast {

--- a/packages/core/src/Toast/toastCreators.tsx
+++ b/packages/core/src/Toast/toastCreators.tsx
@@ -338,28 +338,38 @@ export const createLoadingToast: SimpleToastCreator = ({
  * Progress toast
  */
 
-const ProgressWrapper = styled.div`
+const ProgressWrapper = styled.div<{
+  readonly hasClose: boolean
+}>`
   display: flex;
   align-items: center;
-  padding-left: ${spacing.large};
+  ${({ hasClose }) =>
+    !hasClose
+      ? css`
+          padding: 0 ${spacing.medium} 0 ${spacing.large};
+        `
+      : css`
+          padding-left: ${spacing.large};
+        `}
 `
 
 export const createProgressToast: ProgressToastCreator = ({
   label,
   message,
   progress,
+  hasCloseButton = true,
   ...rest
 }) => {
   const labelComponent = (
     <>
       <ToastLabel
-        hasCloseButton={true}
+        hasCloseButton={hasCloseButton}
         isError={false}
         hasEmphasis={message !== undefined}
       >
         {label}
       </ToastLabel>
-      <ProgressWrapper>
+      <ProgressWrapper hasClose={hasCloseButton}>
         <Progress {...progress} />
       </ProgressWrapper>
     </>
@@ -377,6 +387,7 @@ export const createProgressToast: ProgressToastCreator = ({
     icon,
     label: labelComponent,
     message: messageComponent,
+    hasCloseButton,
     ...rest,
   }
 }


### PR DESCRIPTION
### Describe your changes

Adds the option to remove close `button` from toast.  
We need to remove this button from some toast in ADA in order to avoid giving the user access to the interface while some processes are occurring.


![image](https://user-images.githubusercontent.com/67017215/161098585-5387d56b-bea6-4e4c-a7ed-9d4a524e126e.png)

![image](https://user-images.githubusercontent.com/67017215/161098941-052e7626-bd64-493d-8ef3-16f58ef44d45.png)


### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
