### PR TITLE
fix(dateTimePicker): display midnight as 00.XX

### DIFF
--- a/packages/core/src/DateTimePicker/DateTimeInformation.tsx
+++ b/packages/core/src/DateTimePicker/DateTimeInformation.tsx
@@ -58,9 +58,21 @@ export const DateTimeInformation: VFC<DateTimeInformationProps> = ({
         <TimeIcon height={iconSize.medium} width={iconSize.medium} />
         <Typography variant="page-heading">
           {dateTime.toLocaleString(lang, {
-            hour12,
             hour: 'numeric',
             minute: 'numeric',
+            /**
+             * There is an issue with displaying midnight as 0 or 24.
+             * If hour12 is specified, even as false, it defaults
+             * to hourCycle 'h24'. Not using hour12 if it's false and specifying h23
+             * resolves the issue. The issue exists on chrome-based browsers.
+             *
+             * More information regarding the issue can be found here:
+             * https://github.com/tc39/ecma402/pull/436
+             *
+             * Information regarding hourCycle can be found here:
+             * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/hourCycle
+             */
+            ...(hour12 ? { hour12 } : { hourCycle: 'h23' }),
           })}
         </Typography>
       </DateInfoContainer>


### PR DESCRIPTION
- On some locales, hourCycle is being set to 'h24'
as default if hour12 is specified.

- Removes hour12 if it's false and adds hourCycle: 'h23'

### Issue ticket number and link

- Fixes #221 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
![timepicker_00_XX](https://user-images.githubusercontent.com/77433590/166249263-3d7ca6de-6ce6-4295-b7eb-6f74a991c363.png)

