### PR TITLE
docs: remove stable/experimental icons from menu

### DIFF
--- a/packages/docs/src/mdx/coreComponents/Button.mdx
+++ b/packages/docs/src/mdx/coreComponents/Button.mdx
@@ -1,5 +1,5 @@
 export const meta = {
-  name: 'Button ✔',
+  name: 'Button',
   route: '/components/button',
   menu: 'Components',
 }

--- a/packages/docs/src/mdx/coreComponents/Card.mdx
+++ b/packages/docs/src/mdx/coreComponents/Card.mdx
@@ -1,5 +1,5 @@
 export const meta = {
-  name: 'Card ✔',
+  name: 'Card',
   route: '/components/card',
   menu: 'Components',
 }

--- a/packages/docs/src/mdx/coreComponents/Checkbox.mdx
+++ b/packages/docs/src/mdx/coreComponents/Checkbox.mdx
@@ -1,5 +1,5 @@
 export const meta = {
-  name: 'Checkbox ✔',
+  name: 'Checkbox',
   route: '/components/checkbox',
   menu: 'Components',
 }

--- a/packages/docs/src/mdx/coreComponents/Dialog.mdx
+++ b/packages/docs/src/mdx/coreComponents/Dialog.mdx
@@ -1,5 +1,5 @@
 export const meta = {
-  name: 'Dialog ✔',
+  name: 'Dialog',
   route: '/components/dialog',
   menu: 'Components',
 }

--- a/packages/docs/src/mdx/coreComponents/Divider.mdx
+++ b/packages/docs/src/mdx/coreComponents/Divider.mdx
@@ -1,5 +1,5 @@
 export const meta = {
-  name: 'Divider ✔',
+  name: 'Divider',
   route: '/components/divider',
   menu: 'Components',
 }

--- a/packages/docs/src/mdx/coreComponents/DraggableList.mdx
+++ b/packages/docs/src/mdx/coreComponents/DraggableList.mdx
@@ -1,5 +1,5 @@
 export const meta = {
-  name: 'DraggableList ✔',
+  name: 'DraggableList',
   route: '/components/draggablelist',
   menu: 'Components',
 }

--- a/packages/docs/src/mdx/coreComponents/Input.mdx
+++ b/packages/docs/src/mdx/coreComponents/Input.mdx
@@ -1,5 +1,5 @@
 export const meta = {
-  name: 'Input ✔',
+  name: 'Input',
   route: '/components/input',
   menu: 'Components',
 }

--- a/packages/docs/src/mdx/coreComponents/Menu.mdx
+++ b/packages/docs/src/mdx/coreComponents/Menu.mdx
@@ -1,5 +1,5 @@
 export const meta = {
-  name: 'Menu ✔',
+  name: 'Menu',
   route: '/components/menu',
   menu: 'Components',
 }

--- a/packages/docs/src/mdx/coreComponents/RadioButton.mdx
+++ b/packages/docs/src/mdx/coreComponents/RadioButton.mdx
@@ -1,5 +1,5 @@
 export const meta = {
-  name: 'RadioButton ✔',
+  name: 'RadioButton',
   route: '/components/radiobutton',
   menu: 'Components',
 }

--- a/packages/docs/src/mdx/coreComponents/Select.mdx
+++ b/packages/docs/src/mdx/coreComponents/Select.mdx
@@ -1,5 +1,5 @@
 export const meta = {
-  name: 'Select ✔',
+  name: 'Select',
   route: '/components/select',
   menu: 'Components',
 }

--- a/packages/docs/src/mdx/coreComponents/SelectNative.mdx
+++ b/packages/docs/src/mdx/coreComponents/SelectNative.mdx
@@ -1,5 +1,5 @@
 export const meta = {
-  name: 'SelectNative ✔',
+  name: 'SelectNative',
   route: '/components/selectnative',
   menu: 'Components',
 }

--- a/packages/docs/src/mdx/coreComponents/SimpleTable.mdx
+++ b/packages/docs/src/mdx/coreComponents/SimpleTable.mdx
@@ -1,5 +1,5 @@
 export const meta = {
-  name: 'SimpleTable ⚙',
+  name: 'SimpleTable',
   route: '/components/simpletable',
   menu: 'Components',
 }

--- a/packages/docs/src/mdx/coreComponents/Slider.mdx
+++ b/packages/docs/src/mdx/coreComponents/Slider.mdx
@@ -1,5 +1,5 @@
 export const meta = {
-  name: 'Slider ⚙',
+  name: 'Slider',
   route: '/components/slider',
   menu: 'Components',
 }

--- a/packages/docs/src/mdx/coreComponents/Switch.mdx
+++ b/packages/docs/src/mdx/coreComponents/Switch.mdx
@@ -1,5 +1,5 @@
 export const meta = {
-  name: 'Switch ✔',
+  name: 'Switch',
   route: '/components/switch',
   menu: 'Components',
 }

--- a/packages/docs/src/mdx/coreComponents/Table.mdx
+++ b/packages/docs/src/mdx/coreComponents/Table.mdx
@@ -1,5 +1,5 @@
 export const meta = {
-  name: 'Table ✔',
+  name: 'Table',
   route: '/components/table',
   menu: 'Components',
 }

--- a/packages/docs/src/mdx/coreComponents/TextArea.mdx
+++ b/packages/docs/src/mdx/coreComponents/TextArea.mdx
@@ -1,5 +1,5 @@
 export const meta = {
-  name: 'TextArea ✔',
+  name: 'TextArea',
   route: '/components/textarea',
   menu: 'Components',
 }

--- a/packages/docs/src/mdx/coreComponents/Toast.mdx
+++ b/packages/docs/src/mdx/coreComponents/Toast.mdx
@@ -1,5 +1,5 @@
 export const meta = {
-  name: 'Toast ⚙',
+  name: 'Toast',
   route: '/components/toast',
   menu: 'Components',
 }

--- a/packages/docs/src/mdx/coreComponents/Typography.mdx
+++ b/packages/docs/src/mdx/coreComponents/Typography.mdx
@@ -1,5 +1,5 @@
 export const meta = {
-  name: 'Typography ✔',
+  name: 'Typography',
   route: '/styles/typography',
   menu: 'Styles',
 }


### PR DESCRIPTION
### Describe your changes

The stable / experimental icons in the docs menu no longer serves any purpose. Removing them.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
