### PR TITLE
fix(tooltip): use pointerdown event for touch

### DIFF
--- a/packages/core/src/Tooltip/index.tsx
+++ b/packages/core/src/Tooltip/index.tsx
@@ -265,11 +265,18 @@ export const Tooltip: FC<TooltipProps | ExpandedTooltipProps> = ({
   // If tooltip should be shown
   const visible = visibleByClick || debouncedVisible
 
-  const toggle = useCallback(() => {
-    // When using touch instead of mouse, we have to toggle the tooltip
-    // on "click" instead of "pointerover" and "pointerout"
-    showByClick(v => !v)
-  }, [showByClick])
+  const toggle = useCallback(
+    (event: PointerEvent) => {
+      // When using touch instead of mouse, we have to toggle the tooltip
+      // on "pointerdown" instead of "pointerover" and "pointerout"
+      if (event.pointerType === 'mouse') {
+        return
+      }
+
+      showByClick(v => !v)
+    },
+    [showByClick]
+  )
 
   useEffect(() => {
     const delayVisible = () => setDebouncedVisible(visibleDelayed)
@@ -287,11 +294,11 @@ export const Tooltip: FC<TooltipProps | ExpandedTooltipProps> = ({
     anchorEl.addEventListener('pointerover', showDelayed)
     anchorEl.addEventListener('pointerout', hideDelayed)
     // Event when using touch
-    anchorEl.addEventListener('click', toggle)
+    anchorEl.addEventListener('pointerdown', toggle)
     return () => {
       anchorEl.removeEventListener('pointerover', showDelayed)
       anchorEl.removeEventListener('pointerout', hideDelayed)
-      anchorEl.removeEventListener('click', toggle)
+      anchorEl.removeEventListener('pointerdown', toggle)
     }
   }, [anchorEl, hideDelayed, showDelayed, toggle])
 


### PR DESCRIPTION
Using pointerdown event instead of click
and toggle only if pointerType is not `mouse`

Co-authored-by: Mauricio Espinoza <Mauricio.Espinoza@axis.com>
Co-authored-by: Victor Ingvarsson <Victor.Ingvarsson@axis.com>

- Fixes #232 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
![tooltipfix](https://user-images.githubusercontent.com/77433590/174034463-e06ad0c2-f4fa-409f-a87c-9d45fb75e353.gif)

