### PR TITLE
fix(dialog): make dialogs fit on small screens

### DIFF
--- a/packages/core/src/Dialog/BaseDialog.tsx
+++ b/packages/core/src/Dialog/BaseDialog.tsx
@@ -33,6 +33,7 @@ const DIALOG_WIDTH = {
 const Container = styled.div<{ readonly width: DialogWidth }>`
   max-height: 80vh;
   width: ${({ width }) => DIALOG_WIDTH[width]};
+  max-width: 100vw;
   margin: auto;
   box-shadow: ${({ theme }) => theme.shadow.dialog};
   display: flex;


### PR DESCRIPTION
Adds max-width to dialogs so that they doe not overflow if viewed
on a small screen, such as on a moblie device

### Describe your changes

It is 1 row added so there is not much to summarize. The context is a use case within AXIS Device Assistant (ADA), configuring a connection to a wireless network. Unlike most use cases in ADA this is meant to be done on a mobile device. At the end of the process there is a confirmation dialog and with the current code it overflows such that . See attached images

![dialogoverflow](https://user-images.githubusercontent.com/32322627/179969894-399f0e48-35d2-4e61-8199-9aad3d510399.png)
![installmodeconfirm](https://user-images.githubusercontent.com/32322627/179969898-a110e61b-b2ac-467e-a314-9274fc762ec0.png)

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
