### PR TITLE
feat(toast): use toasts from context

### DIFF
--- a/packages/core/src/Toast/context.ts
+++ b/packages/core/src/Toast/context.ts
@@ -1,4 +1,4 @@
-import { createContext, ReactNode, MutableRefObject, Dispatch } from 'react'
+import { createContext, ReactNode, Dispatch } from 'react'
 import { IconType } from '../Icon'
 import { ALinkProps, ButtonLinkProps } from '../Link'
 
@@ -24,6 +24,8 @@ export interface ProgressToast extends SimpleToast {
     readonly label: string
   }
 }
+
+export type ToastsMap = ReadonlyMap<ToastId, BaseToastValue>
 
 export type ShowToastHandler = (toast: BaseToastValue, id?: ToastId) => ToastId
 export type HideToastHandler = (id: ToastId) => void
@@ -88,7 +90,8 @@ export const NI = () => {
   throw new Error(`Not implemented: no ToastContext set`)
 }
 export interface ToastContextType extends ToastCallbacks {
-  readonly __dispatchRef: MutableRefObject<Dispatch<ToastAction>>
+  readonly dispatch: Dispatch<ToastAction>
+  readonly toasts: ToastsMap
 }
 
 export const ToastsContext = createContext<ToastContextType>({
@@ -102,5 +105,6 @@ export const ToastsContext = createContext<ToastContextType>({
   showLoadingToast: NI,
   showProgressToast: NI,
   showActionToast: NI,
-  __dispatchRef: { current: NI },
+  dispatch: NI,
+  toasts: new Map(),
 })

--- a/packages/core/src/Toast/index.ts
+++ b/packages/core/src/Toast/index.ts
@@ -7,3 +7,4 @@ export {
   ToastIconWrapper,
   ToastIconType,
 } from './toastCreators'
+export { ToastContent } from './ToastsProvider'

--- a/packages/core/src/Toast/toastReducer.ts
+++ b/packages/core/src/Toast/toastReducer.ts
@@ -1,11 +1,4 @@
-import {
-  BaseToastValue,
-  ToastAction,
-  ToastActionType,
-  ToastId,
-} from './context'
-
-export type ToastsMap = ReadonlyMap<ToastId, BaseToastValue>
+import { ToastAction, ToastActionType, ToastsMap } from './context'
 
 /**
  * Given the current state (toast map) and an action,

--- a/packages/core/src/Toast/useToasts.ts
+++ b/packages/core/src/Toast/useToasts.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject, Dispatch, useContext, useCallback } from 'react'
+import { Dispatch, useContext, useCallback } from 'react'
 
 import { createToast, removeToast, removeAllToasts } from './toastActions'
 import {
@@ -30,29 +30,27 @@ export interface SimpleToastsDurations {
 }
 
 export const useToastCallbacks = (
-  dispatchRef: MutableRefObject<Dispatch<ToastAction>>,
+  dispatch: Dispatch<ToastAction>,
   { success, error, warning, info }: SimpleToastsDurations = {}
 ): ToastCallbacks => {
   const showToast: ShowToastHandler = useCallback(
     (toast, id) => {
       const toastAction = createToast(toast, id)
-      dispatchRef.current(toastAction)
+      dispatch(toastAction)
       return toastAction.id
     },
-    [dispatchRef]
+    [dispatch]
   )
 
   const hideToast: HideToastHandler = useCallback(
     id => {
       const toastAction = removeToast(id)
-      dispatchRef.current(toastAction)
+      dispatch(toastAction)
     },
-    [dispatchRef]
+    [dispatch]
   )
 
-  const clearToasts = useCallback(() => {
-    dispatchRef.current(removeAllToasts)
-  }, [dispatchRef])
+  const clearToasts = useCallback(() => dispatch(removeAllToasts), [dispatch])
 
   const showSuccessToast: SimpleToastCreator = useCallback(
     (toast, id) =>
@@ -111,7 +109,7 @@ export const useToastCallbacks = (
 }
 
 export const useToasts = () => {
-  const { __dispatchRef, ...callbacks } = useContext(ToastsContext)
+  const { dispatch, toasts, ...callbacks } = useContext(ToastsContext)
 
   return callbacks
 }


### PR DESCRIPTION
### Describe your changes

Enables use of multiple ToastAnchors throughout the application sharing the toasts.
Moves the ToastMap to the ToastProvider

### Issue ticket number and link

- Fixes #241 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
