### PR TITLE
feat: secondary progress

### DIFF
--- a/packages/core/src/Progress/index.tsx
+++ b/packages/core/src/Progress/index.tsx
@@ -7,6 +7,13 @@ import { spacing, shape } from '../designparams'
 type BaseElement = HTMLDivElement
 type BaseProps = HTMLAttributes<BaseElement>
 
+type ProgressMeterVariants = 'primary' | 'secondary'
+
+interface ProgressMeterProps {
+  readonly fraction: number
+  readonly variant: ProgressMeterVariants
+}
+
 const ProgressContainer = styled.div`
   display: flex;
   align-items: center;
@@ -22,8 +29,11 @@ const ProgressIndicator = styled.div`
   overflow: hidden;
 `
 
-const ProgressMeter = styled.div<{ readonly fraction: number }>`
-  background-color: ${({ theme }) => theme.color.elementPrimary()};
+const ProgressMeter = styled.div<ProgressMeterProps>`
+  background-color: ${({ theme, variant }) =>
+    variant === 'primary'
+      ? theme.color.elementPrimary()
+      : theme.color.element14()};
   border-radius: inherit;
   height: 100%;
   width: ${({ fraction }) => `${Math.round(fraction * 100)}%`};
@@ -50,12 +60,21 @@ export interface ProgressProps extends BaseProps {
    * A string used to tell the user information regarding the progress value.
    */
   readonly label: string
+  /**
+   * Primary or secondary variant of the progress meter
+   */
+  readonly variant?: ProgressMeterVariants
 }
 
-export const Progress: FC<ProgressProps> = ({ value, label, ...props }) => (
+export const Progress: FC<ProgressProps> = ({
+  value,
+  label,
+  variant = 'primary',
+  ...props
+}) => (
   <ProgressContainer {...props}>
     <ProgressIndicator>
-      <ProgressMeter fraction={value} />
+      <ProgressMeter fraction={value} variant={variant} />
     </ProgressIndicator>
     <ProgressLabel>{label}</ProgressLabel>
   </ProgressContainer>

--- a/packages/docs/src/mdx/coreComponents/Progress.mdx
+++ b/packages/docs/src/mdx/coreComponents/Progress.mdx
@@ -5,7 +5,11 @@ export const meta = {
 }
 
 import styled from 'styled-components'
-import { Progress } from 'practical-react-components-core'
+import {
+  Progress,
+  SpaceBlock,
+  Typography,
+} from 'practical-react-components-core'
 
 # Progress
 
@@ -15,14 +19,23 @@ A Progress inform users about the status of ongoing progresses.
 
 export const total = 84
 export const data = 31
-export const value = (data / total).toFixed(2)
+export const value = parseFloat((data / total).toFixed(2))
 
+<Typography>Primary</Typography>
 <Progress value={value} label={`${data}/${total}Mb`} className="progress" />
+<SpaceBlock variant={32} />
+<Typography>Secondary</Typography>
+<Progress
+  value={value}
+  label={`${data}/${total}Mb`}
+  className="progress"
+  variant="secondary"
+/>
 
 ## Basic usage
 
 ```typescript type="live"
-<Progress value={0.5} label="50%" />
+<Progress value={0.5} label="50%" variant="primary" />
 ```
 
 ## Props


### PR DESCRIPTION
### Describe your changes

Adds a "secondary" variant to the the progress. This will not break any existing usage of this component since the "primary" color will be default for the progress bar.

![Screenshot from 2022-11-07 10-11-47](https://user-images.githubusercontent.com/7765599/200285499-f57a12d4-c020-4ebc-9383-3bfec7a76deb.png)

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
