### PR TITLE
fix(checkbox): only checkbox-area is clickable

### DIFF
--- a/packages/core/src/Checkbox/index.tsx
+++ b/packages/core/src/Checkbox/index.tsx
@@ -100,7 +100,7 @@ const Container = styled.div<{
   ${({ hasLabel }) =>
     hasLabel
       ? css`
-          width: 100%;
+          width: auto;
           justify-content: flex-start;
           padding-left: 3px;
           > span {


### PR DESCRIPTION
Fixed an issue with being able to click outside of the checkbox to trigger a toggle.

### Describe your changes

Changed the width in the Checkbox component to be auto instead of fixed 100%

### Issue ticket number and link

- Fixes #252 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
