### PR TITLE
feat(modal): allowoutsideclick optional prop

### DIFF
--- a/packages/core/src/Modal/index.tsx
+++ b/packages/core/src/Modal/index.tsx
@@ -123,6 +123,11 @@ export interface ModalProps extends BaseProps {
    * When `true` the dialog is rendered, `false` removes the dialog.
    */
   readonly open: boolean
+  /**
+   * If `true`, clicking outside the modal is possible, `false` does not allow
+   * clicking outside the modal.
+   */
+  readonly allowOutsideClick?: boolean
 }
 
 export const Modal: FC<ModalProps> = ({
@@ -130,6 +135,7 @@ export const Modal: FC<ModalProps> = ({
   onClose,
   focusDialog = true,
   children,
+  allowOutsideClick = true,
   ...props
 }) => {
   useEffect(() => {
@@ -156,7 +162,7 @@ export const Modal: FC<ModalProps> = ({
         focusTrapOptions={{
           initialFocus: focusDialog ? `#${id}` : undefined,
           escapeDeactivates: false, // We use our own stack
-          clickOutsideDeactivates: true, // 😱😱😱 We need this to prevent click capturing
+          clickOutsideDeactivates: allowOutsideClick,
         }}
       >
         <FocusWrapper tabIndex={-1} id={id}>


### PR DESCRIPTION
### Describe your changes

Adding prop allowOutsideClick which is optional.
Default value is true, changing it to false stops the user from clicking outside the component, which stops the behavior of tabbing outside a component to be possible.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
