### PR TITLE
fix(transition): transition to expand component in development

### DIFF
--- a/packages/core/src/Transition/FoldTransition.tsx
+++ b/packages/core/src/Transition/FoldTransition.tsx
@@ -35,6 +35,7 @@ export const FoldTransition: FC<FoldTransitionProps> = ({
     const node = nodeRef.current
 
     const height = node.offsetHeight
+    if (height === 0) return
     transitionHeight(node, 0, height)
   }, [])
 


### PR DESCRIPTION
### Describe your changes

Fix transition animation for expandable components in development.
Set only the initial offsetHeight of html elements for increaseHeight,
because in development when react runs in strict mode, the height of the component is set twice.

Also, create a [bug report](https://github.com/AxisCommunications/practical-react-components/issues/256)

###  Fixes #256 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
