### PR TITLE
fix(tooltip): wrap ExpandedTooltipTitle overflow

### DIFF
--- a/packages/core/src/Tooltip/index.tsx
+++ b/packages/core/src/Tooltip/index.tsx
@@ -96,7 +96,7 @@ const ExpandedTooltipTitle = styled(Typography).attrs({
   variant: 'chip-tag-text',
 })`
   font-weight: ${font.fontWeight.semibold};
-  white-space: nowrap;
+  white-space: normal;
 `
 
 const ExpandedTooltipExtraInfo = styled(Typography).attrs({


### PR DESCRIPTION
### Describe your changes

Change 'white-space: nowrap' attribute to 'white-space: normal' in ExpandedTooltipTitle component CSS.

### Issue ticket number and link

- Fixes [#264](https://github.com/AxisCommunications/practical-react-components/issues/264)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
