### PR TITLE
feat(slider): adds `onPressed` and `onKnobMoved` props to allow for customization

### DIFF
--- a/packages/core/src/Slider/index.tsx
+++ b/packages/core/src/Slider/index.tsx
@@ -302,6 +302,14 @@ export interface SliderProps extends BaseProps {
    * Configuration for displaying ticks in the slider
    */
   readonly tickConfig?: TickConfig
+  /**
+   * Executes JavaScript when a user presses the knob
+   */
+  readonly onPressed?: (pressed: boolean) => void
+  /**
+   * Returns the current knob position in the X-axis
+   */
+  readonly onKnobMove?: (value: number) => void
 }
 
 export const Meta = styled.div`
@@ -334,6 +342,8 @@ export const Slider: FC<SliderProps> = ({
   onPointerDown,
   onPointerUp,
   onFocus,
+  onPressed,
+  onKnobMove,
   tickConfig = {
     ticks: [],
   },
@@ -355,6 +365,11 @@ export const Slider: FC<SliderProps> = ({
   const fraction = useMemo(
     () => clamp((value - min) / (max - min)),
     [max, min, value]
+  )
+
+  const sliderPosition = useMemo(
+    () => fraction * sliderWidth,
+    [fraction, sliderWidth]
   )
 
   // Generate the ticks with its position along the x-axis
@@ -440,6 +455,16 @@ export const Slider: FC<SliderProps> = ({
       }
     }
   }, [handleClick, pressed])
+
+  // Trigger callback when the knob is moved along the X-axis
+  useEffect(() => {
+    onKnobMove?.(sliderPosition)
+  }, [sliderPosition])
+
+  // Trigger callback when knob is pressed
+  useEffect(() => {
+    onPressed?.(pressed)
+  }, [pressed])
 
   const getNextSnap = useCallback(
     () => snapValues.find(snapValue => snapValue > fraction),
@@ -597,9 +622,7 @@ export const Slider: FC<SliderProps> = ({
             fraction={fraction}
             pressed={pressed}
             style={{
-              transform: `translateX(-50%) translateX(${
-                fraction * sliderWidth
-              }px)`,
+              transform: `translateX(-50%) translateX(${sliderPosition}px)`,
             }}
             ref={knobRef}
           >


### PR DESCRIPTION
### Describe your changes

We would like to build a custom slider with an indicator popup above the knob showing what the value of the slider is when pressed and when the knob is being moved.

This PR replaces this [PR 171](https://github.com/AxisCommunications/practical-react-components/pull/171) as we want to do the custom slider inside our project.

This PR adds two optional props `onPressed` and `onKnobMoved` that would allow us to archive this behavior in our project.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
