### PR TITLE
fix(tooltip): hide tooltip when touched outside of a component

### DIFF
--- a/packages/core/src/Tooltip/__snapshots__/index.test.tsx.snap
+++ b/packages/core/src/Tooltip/__snapshots__/index.test.tsx.snap
@@ -33,7 +33,9 @@ exports[`Tooltip Default 1`] = `
       className="c1"
       id="layer-1"
     >
-      <span>
+      <span
+        onPointerDown={[Function]}
+      >
         Test
       </span>
     </div>
@@ -84,7 +86,9 @@ exports[`Tooltip Expanded 1`] = `
       className="c1"
       id="layer-3"
     >
-      <span>
+      <span
+        onPointerDown={[Function]}
+      >
         Test
       </span>
     </div>
@@ -135,7 +139,9 @@ exports[`Tooltip Expanded 2`] = `
       className="c1"
       id="layer-5"
     >
-      <span>
+      <span
+        onPointerDown={[Function]}
+      >
         Test
       </span>
     </div>
@@ -186,7 +192,9 @@ exports[`Tooltip Expanded 3`] = `
       className="c1"
       id="layer-7"
     >
-      <span>
+      <span
+        onPointerDown={[Function]}
+      >
         Test
       </span>
     </div>

--- a/packages/ui-tests/src/coreComponents/Tooltip.spec.ts
+++ b/packages/ui-tests/src/coreComponents/Tooltip.spec.ts
@@ -85,25 +85,15 @@ context('Tooltip mobile device', { testIsolation: false }, () => {
     cy.get(`[data-cy=${data.tooltipDataCy}]`).should('not.exist')
   })
 
-  it(`Tooltip ${data.tooltipDataCy} should hide when client touch move more than 150 pixels`, () => {
+  it(`Tooltip ${data.tooltipDataCy} should hide when client touch the screen again`, () => {
     // Touch to show tooltip
     cy.get(`[data-cy=${data.textDataCy}]`).trigger('pointerdown')
     cy.get(`[data-cy=${data.tooltipDataCy}]`)
       .should('exist')
       .should('be.visible')
 
-    // Touch move 151 pixels and hide tooltip
-    cy.get(`[data-cy=${data.textDataCy}]`)
-      .parent()
-      .trigger('touchstart', {
-        touches: [{ clientX: 0, clientY: 0, identifier: 0 }],
-      })
-
-    cy.get(`[data-cy=${data.textDataCy}]`)
-      .parent()
-      .trigger('touchmove', {
-        changedTouches: [{ clientX: 151, clientY: 151, identifier: 0 }],
-      })
+    // Touch the screen again
+    cy.get(`[data-cy=${data.textDataCy}]`).parent().trigger('pointerdown')
 
     // Tooltip is not shown
     cy.get(`[data-cy=${data.tooltipDataCy}]`).should('not.exist')


### PR DESCRIPTION
Fixes: #276

### Describe your changes

Imported useClickOutside from 'react-hooks-shareable' and added it to onPointerDown event.

### Issue ticket number and link

- Fixes #276 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
